### PR TITLE
Add error message in Makefile.am when SWIG generated files are missing.

### DIFF
--- a/modulesrc/geocoords/Makefile.am
+++ b/modulesrc/geocoords/Makefile.am
@@ -44,6 +44,9 @@ _geocoordsmodule_la_LIBADD = \
 if ENABLE_SWIG
 $(srcdir)/geocoords_wrap.cxx $(srcdir)/geocoords.py: $(swig_sources)
 	$(SWIG) -Wall -c++ -python $<
+else
+$(srcdir)/geocoords_wrap.cxx $(srcdir)/geocoords.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/spatialdb/Makefile.am
+++ b/modulesrc/spatialdb/Makefile.am
@@ -57,6 +57,9 @@ _spatialdbmodule_la_LIBADD = \
 if ENABLE_SWIG
 $(srcdir)/spatialdb_wrap.cxx $(srcdir)/spatialdb.py: $(swig_sources)
 	$(SWIG) -Wall -c++ -python $<
+else
+$(srcdir)/spatialdb_wrap.cxx $(srcdir)/spatialdb.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/units/Makefile.am
+++ b/modulesrc/units/Makefile.am
@@ -41,6 +41,9 @@ _unitsmodule_la_LIBADD = \
 if ENABLE_SWIG
 $(srcdir)/units_wrap.cxx $(srcdir)/units.py: $(swig_sources)
 	$(SWIG) -Wall -c++ -python $<
+else
+$(srcdir)/units_wrap.cxx $(srcdir)/units.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 

--- a/modulesrc/utils/Makefile.am
+++ b/modulesrc/utils/Makefile.am
@@ -41,6 +41,9 @@ _utilsmodule_la_LIBADD = \
 if ENABLE_SWIG
 $(srcdir)/utils_wrap.cxx $(srcdir)/utils.py: $(swig_sources)
 	$(SWIG) -Wall -c++ -python $<
+else
+$(srcdir)/utils_wrap.cxx $(srcdir)/utils.py:
+	$(error Missing SWIG generated files. Make sure SWIG is installed and reconfigure with --enable-swig)
 endif
 
 


### PR DESCRIPTION
Added error message to `modulesrc/*/Makefile.am`.