### PR TITLE
Readd CentOS test runners. Check for lcov to run test coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,17 @@ matrix:
       env: BASE_IMAGE=geodynamics/pylith-testenv-fedora-31
     - os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-fedora-32
+    - os: linux
+      env: BASE_IMAGE=geodynamics/pylith-testenv-centos-6
+    - os: linux
+      env: BASE_IMAGE=geodynamics/pylith-testenv-centos-7
+    - os: linux
+      env: BASE_IMAGE=geodynamics/pylith-testenv-centos-8
 
 #    - os: linux
 #      env: BASE_IMAGE=geodynamics/pylith-testenv-debian-testing-clang8
 #    - os: linux
 #      env: BASE_IMAGE=geodynamics/pylith-testenv-debian-testing-clang9
-#    - os: linux
-#      env: BASE_IMAGE=geodynamics/pylith-testenv-centos-6
-#    - os: linux
-#      env: BASE_IMAGE=geodynamics/pylith-testenv-centos-7
 
 
 addons:

--- a/ci-config/run_test_coverage.sh
+++ b/ci-config/run_test_coverage.sh
@@ -4,9 +4,15 @@
 
 make -j$(nproc) install
 make -j$(nproc) check VERBOSE=1
-make coverage-libsrc
 
-# Must run codeocov script in top-level source directory.
-cd ../../src/spatialdata && bash <(curl -s https://codecov.io/bash) -X gcov -f ../../build/spatialdata/coverage.info -F libsrc -y ci-config/codecov.yml
+LCOV=`which lcov`
+if test -f $LCOV; then
+  make coverage-libsrc
 
+  # Must run codeocov script in top-level source directory.
+  cd ../../src/spatialdata && bash <(curl -s https://codecov.io/bash) -X gcov -f ../../build/spatialdata/coverage.info -F libsrc -y ci-config/codecov.yml
+else
+    echo "lcov not found. Skipping test coverage."
+fi
+  
 exit 0


### PR DESCRIPTION
Add CentOS test runners that were temporarily removed (builds failed).

CentOS 8 doesn't include lcov package. Only run test coverage if lcov is present.