### PR TITLE
Add Fedora 33 test environment (disabled)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,50 @@
 # Travis-CI configuration
 
-sudo: true
 services:
     - docker
 
 language: cpp
 
 # :TODO: @brad Add osx build (need homebrew packages)..
-matrix:
+jobs:
   include:
-    - os: linux
+    - name: debian-stable-gcc8
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-debian-stable-gcc8 TEST_COVERAGE=yes PYTHON_COVERAGE=python2-coverage
-    - os: linux
+    - name: debian-testing-gcc9
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-debian-testing-gcc9 TEST_COVERAGE=yes PYTHON_COVERAGE=python2-coverage
-    - os: linux
+    - name: ubuntu-18.04
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-ubuntu-18.04 TEST_COVERAGE=yes PYTHON_COVERAGE=python2-coverage
-    - os: linux
+    - name: ubuntu-19.10
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-ubuntu-19.10 TEST_COVERAGE=yes PYTHON_COVERAGE=python2-coverage
-    - os: linux
+    - name: ubuntu-20.04
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-ubuntu-20.04 TEST_COVERAGE=yes PYTHON_COVERAGE=python2-coverage
-    - os: linux
+    - name: fedora-30
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-fedora-30 TEST_COVERAGE=yes PYTHON_COVERAGE=coverage2
-    - os: linux
+    - name: fedora-31
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-fedora-31 TEST_COVERAGE=yes PYTHON_COVERAGE=coverage2
-    - os: linux
+    - name: fedora-32
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-fedora-32
-    - os: linux
+    - name: centos-6
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-centos-6
-    - os: linux
+    - name: centos-7
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-centos-7
-    - os: linux
+    - name: centos-8
+      os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-centos-8
 
 # Permissions problem with BUILD_DIR for nemesis.
-#    - os: linux
+#    - name: fedora-33
+#      os: linux
 #      env: BASE_IMAGE=geodynamics/pylith-testenv-fedora-33
 
 #    - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
     - os: linux
       env: BASE_IMAGE=geodynamics/pylith-testenv-centos-8
 
+# Permissions problem with BUILD_DIR for nemesis.
+#    - os: linux
+#      env: BASE_IMAGE=geodynamics/pylith-testenv-fedora-33
+
 #    - os: linux
 #      env: BASE_IMAGE=geodynamics/pylith-testenv-debian-testing-clang8
 #    - os: linux

--- a/configure.ac
+++ b/configure.ac
@@ -30,17 +30,24 @@ AC_ARG_ENABLE([swig],
 	[enable_swig=no])
 AM_CONDITIONAL([ENABLE_SWIG], [test "$enable_swig" = yes])
 
-# TESTING w/cppunit and pytest
+# TESTING w/cppunit and Python unittest
 AC_ARG_ENABLE([testing],
 	[  --enable-testing        Enable unit testing with cppunit (requires cppunit) [[default=no]]],
 	[if test "$enableval" = yes ; then enable_testing=yes; else enable_testing=no; fi],
 	[enable_testing=no])
+AM_CONDITIONAL([ENABLE_TESTING], [test "$enable_testing" = yes])
 
 # TEST COVERAGE w/locv and python-coverage
 AC_ARG_ENABLE([test-coverage],
 	[  --enable-test-coverage  Enable test coverage with lcov and python-coverage [[default=no]]],
 	[if test "$enableval" = yes ; then enable_test_coverage=yes; else enable_test_coverage=no; fi],
 	[enable_test_coverage=no])
+AC_ARG_WITH([python-coverage],
+    [AC_HELP_STRING([--with-python-coverage],
+        [set executable for python-coverage @<:@default=coverage2@:>@])],
+	[python_coverage=$withval],
+	[python_coverage="coverage2"])
+AC_SUBST(python_coverage)
 
 # PYTHIA w/pythia
 enable_pythia=yes
@@ -54,13 +61,6 @@ AC_ARG_ENABLE([scec-cvm-h],
 	[  --enable-scec-cvm-h=DIR    Enable unit testing with SCEC CVM-H (requires cppunit and SCEC CVM-H data files) [[default=no]]],
 	[],
 	[enable_scec_cvm_h=no])
-
-AC_ARG_WITH([python-coverage],
-    [AC_HELP_STRING([--with-python-coverage],
-        [set executable for python-coverage @<:@default=coverage2@:>@])],
-	[python_coverage=$withval],
-	[python_coverage="coverage2"])
-AC_SUBST(python_coverage)
 
 # ----------------------------------------------------------------------
 AC_PROG_CXX
@@ -80,7 +80,6 @@ CIT_PROJ6_HEADER
 CIT_PROJ6_LIB
 
 # CPPUNIT
-AM_CONDITIONAL([ENABLE_TESTING], [test "$enable_testing" = yes])
 if test "$enable_testing" = "yes" ; then
   CIT_CPPUNIT_HEADER
   CIT_CPPUNIT_LIB

--- a/docker/spatialdata-testenv
+++ b/docker/spatialdata-testenv
@@ -1,4 +1,4 @@
-# docker build --build-arg BASE_IMAGE=${VARIABLE_NAME} --build-arg CODE_COVERAGE=yes/no --build-arg PYTHON_COVERAGE=${COVERAGE_EXECUTABLE} -f DOCKERFILE . -t IMAGE_NAME .
+# docker build --build-arg BASE_IMAGE=${VARIABLE_NAME} --build-arg TEST_COVERAGE=yes/no --build-arg PYTHON_COVERAGE=${COVERAGE_EXECUTABLE} -f DOCKERFILE . -t IMAGE_NAME .
 
 # BUILD CIG DEPENDENCIES ----------
 ARG BASE_IMAGE


### PR DESCRIPTION
Add Fedora 33 test environment, but disable it due to permissions error. This seems to be an issued with the Fedora 33 image as all of the other containers are fine.

Add configure option for setting the python-coverage executable (os dependent).

Add names to Travis CI test environments.