### PR TITLE
Set default query values to all values in spatial database.

### DIFF
--- a/libsrc/spatialdata/spatialdb/SCECCVMH.cc
+++ b/libsrc/spatialdata/spatialdb/SCECCVMH.cc
@@ -49,10 +49,15 @@ spatialdata::spatialdb::SCECCVMH::SCECCVMH(void) :
     _squashLimit(-2000.0),
     _minVs(0.0),
     _queryValues(NULL),
-    _querySize(0),
+    _querySize(7),
     _squashTopo(false) {
     assert(_csUTM);
     _csUTM->setString("+proj=utm +zone=11 +datum=NAD27 +units=m +type=crs");
+
+    _queryValues = (_querySize > 0) ? new size_t[_querySize] : NULL;
+    for (size_t i = 0; i < _querySize; ++i) {
+        _queryValues[i] = i;
+    } // for
 } // constructor
 
 

--- a/libsrc/spatialdata/spatialdb/SimpleDB.cc
+++ b/libsrc/spatialdata/spatialdb/SimpleDB.cc
@@ -95,7 +95,16 @@ spatialdata::spatialdb::SimpleDB::open(void) {
     // Create query object
     if (!_query) {
         _query = new SimpleDBQuery(*this);
-    }
+    } // if
+
+    // Set default query values to all values in database
+    const size_t numValues = _data->getNumValues();
+    const char** queryValues = (numValues > 0) ? new const char*[numValues] : NULL;
+    for (size_t i = 0; i < numValues; ++i) {
+        queryValues[i] = _data->getName(i);
+    } // for
+    _query->setQueryValues(queryValues, numValues);
+    delete[] queryValues;queryValues = NULL;
 } // open
 
 

--- a/libsrc/spatialdata/spatialdb/SimpleGridDB.cc
+++ b/libsrc/spatialdata/spatialdb/SimpleGridDB.cc
@@ -92,6 +92,13 @@ spatialdata::spatialdb::SimpleGridDB::open(void) {
     // Convert to SI units
     const size_t numLocs = (3 == _spaceDim) ? _numX * _numY * _numZ : (2 == _spaceDim) ? _numX * _numY : _numX;
     SpatialDB::_convertToSI(_data, _units, numLocs, _numValues);
+
+    // Default query values is all values.
+    _querySize = _numValues;
+    delete[] _queryValues;_queryValues = (_querySize > 0) ? new size_t[_querySize] : NULL;
+    for (size_t i = 0; i < _querySize; ++i) {
+        _queryValues[i] = i;
+    } // for
 } // open
 
 
@@ -110,6 +117,9 @@ spatialdata::spatialdb::SimpleGridDB::close(void) {
     _numValues = 0;
     delete[] _names;_names = NULL;
     delete[] _units;_units = NULL;
+
+    _querySize = 0;
+    delete[] _queryValues;_queryValues = NULL;
 } // close
 
 

--- a/libsrc/spatialdata/spatialdb/UniformDB.cc
+++ b/libsrc/spatialdata/spatialdb/UniformDB.cc
@@ -55,7 +55,7 @@ spatialdata::spatialdb::UniformDB::UniformDB(const char* label) :
 
 // ----------------------------------------------------------------------
 /// Default destructor
-spatialdata::spatialdb::UniformDB::~UniformDB(void) { // destructor
+spatialdata::spatialdb::UniformDB::~UniformDB(void) {
     delete[] _names;_names = NULL;
     delete[] _values;_values = NULL;
     delete[] _queryValues;_queryValues = NULL;
@@ -79,9 +79,12 @@ spatialdata::spatialdb::UniformDB::setData(const char* const* names,
     delete[] _values;_values = NULL;
     _numValues = numValues;
 
+    delete[] _queryValues;_queryValues = NULL;
+    _querySize = 0;
+
     spatialdata::units::Parser parser;
 
-    if (0 < numValues) {
+    if (numValues > 0) {
         _names = new std::string[numValues];
         for (size_t i = 0; i < numValues; ++i) {
             _names[i] = names[i];
@@ -99,6 +102,13 @@ spatialdata::spatialdb::UniformDB::setData(const char* const* names,
         _values = new double[numValues];
         for (size_t i = 0; i < numValues; ++i) {
             _values[i] = values[i]*scales[i];
+        } // for
+
+        // Default query values is all values.
+        _querySize = _numValues;
+        delete[] _queryValues;_queryValues = (_querySize > 0) ? new size_t[_querySize] : NULL;
+        for (size_t i = 0; i < _querySize; ++i) {
+            _queryValues[i] = i;
         } // for
     } // if
 } // setData

--- a/libsrc/spatialdata/spatialdb/UserFunctionDB.cc
+++ b/libsrc/spatialdata/spatialdb/UserFunctionDB.cc
@@ -180,6 +180,14 @@ spatialdata::spatialdb::UserFunctionDB::open(void) {
     } // for
 
     _checkCompatibility();
+
+    // Default query values is all values.
+    _querySize = _functions.size();
+    delete[] _queryFunctions;_queryFunctions = (_querySize > 0) ? new UserData*[_querySize] : NULL;
+    size_t index = 0;
+    for (function_map::iterator iter = _functions.begin(); iter != _functions.end(); ++iter, ++index) {
+        _queryFunctions[index] = &iter->second;
+    } // for
 } // open
 
 

--- a/libsrc/spatialdata/spatialdb/UserFunctionDB.hh
+++ b/libsrc/spatialdata/spatialdb/UserFunctionDB.hh
@@ -219,7 +219,7 @@ private:
     UserData** _queryFunctions; ///< Array of pointers to _functions of values to be returned in queries.
     std::map<std::string, UserData> _functions; ///< User functions for values.
     geocoords::CoordSys* _cs; ///< Coordinate system
-    int _querySize; ///< Number of values to be returned in queries.
+    size_t _querySize; ///< Number of values to be returned in queries.
 
     // NOT IMPLEMENTED //////////////////////////////////////////////////////
 private:

--- a/tests/libtests/spatialdb/TestGravityField.cc
+++ b/tests/libtests/spatialdb/TestGravityField.cc
@@ -45,6 +45,12 @@ spatialdata::spatialdb::TestGravityField::tearDown(void) {
 void
 spatialdata::spatialdb::TestGravityField::testConstructor(void) {
     GravityField db;
+
+    const size_t numValues = 3;
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query size.", size_t(numValues), db._querySize);
+    for (size_t i = 0; i < numValues; ++i) {
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query values.", i, db._queryValues[i]);
+    } // for
 } // testConstructor
 
 

--- a/tests/libtests/spatialdb/TestSCECCVMH.cc
+++ b/tests/libtests/spatialdb/TestSCECCVMH.cc
@@ -81,6 +81,12 @@ CPPUNIT_TEST_SUITE_REGISTRATION(spatialdata::spatialdb::TestSCECCVMH);
 void
 spatialdata::spatialdb::TestSCECCVMH::testConstructor(void) {
     SCECCVMH db;
+
+    const size_t numValues = 7;
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query size.", numValues, db._querySize);
+    for (size_t i = 0; i < numValues; ++i) {
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query values.", i, db._queryValues[i]);
+    } // for
 } // testConstructor
 
 

--- a/tests/libtests/spatialdb/TestSimpleGridDB.cc
+++ b/tests/libtests/spatialdb/TestSimpleGridDB.cc
@@ -250,6 +250,13 @@ spatialdata::spatialdb::TestSimpleGridDB::testRead(void) {
     for (size_t i = 0; i < totalSize; ++i) {
         CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE("Mismatch in data values.", _data->dbData[i], db._data[i], tolerance);
     } // for
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query size.", _data->numValues, db._querySize);
+    for (size_t i = 0; i < _data->numValues; ++i) {
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query values.", i, db._queryValues[i]);
+    } // for
+
+    db.close();
 } // testRead
 
 

--- a/tests/libtests/spatialdb/TestUniformDB.cc
+++ b/tests/libtests/spatialdb/TestUniformDB.cc
@@ -112,6 +112,11 @@ spatialdata::spatialdb::TestUniformDB::testSetData(void) {
     for (size_t i = 0; i < numValues; ++i) {
         CPPUNIT_ASSERT_EQUAL(valuesE[i], db._values[i]);
     } // for
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query size.", numValues, db._querySize);
+    for (size_t i = 0; i < numValues; ++i) {
+        CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query values.", i, db._queryValues[i]);
+    } // for
 } // testSetData
 
 

--- a/tests/libtests/spatialdb/TestUserFunctionDB.cc
+++ b/tests/libtests/spatialdb/TestUserFunctionDB.cc
@@ -100,12 +100,15 @@ spatialdata::spatialdb::TestUserFunctionDB::testOpenClose(void) {
     // Test open() and close() with valid data.
     _db->open();
     // Verify scales
-    const int numValues = _data->numValues;
+    const size_t numValues = _data->numValues;
     const double tolerance = 1.0e-6;
-    for (int i = 0; i < numValues; ++i) {
+    for (size_t i = 0; i < numValues; ++i) {
         const std::string& name = _data->values[i].name;
         CPPUNIT_ASSERT_DOUBLES_EQUAL(_data->values[i].scale, _db->_functions[name].scale, tolerance);
     } // for
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in default query size.", numValues, _db->_querySize);
+
     _db->close();
     CPPUNIT_ASSERT(!_db->_queryFunctions);
 


### PR DESCRIPTION
By default, queries should return all values in the spatial database. In most cases, the user will set the values they want via `setQueryValues().`

Closes https://github.com/geodynamics/spatialdata/issues/28.