### PR TITLE
Require spatial database files to exist in validator.

### DIFF
--- a/spatialdata/spatialdb/SimpleGridAscii.py
+++ b/spatialdata/spatialdb/SimpleGridAscii.py
@@ -104,9 +104,8 @@ class SimpleGridAscii(Component, ModuleSimpleGridAscii):
 
         from SimpleGridDB import SimpleGridDB
         db = SimpleGridDB()
-        db.inventory.label = "Temporary database for I/O"
-        db.inventory.filename = self.filename
-        db._configure()
+        db.setLabel("Temporary SimpleGridDB for writing")
+        db.setFilename(self.filename)
         db.setCoordSys(data['coordsys'])
         db.allocate(numX, numY, numZ, numValues, spaceDim, data['data_dim'])
         db.setX(data['x'])
@@ -125,13 +124,7 @@ class SimpleGridAscii(Component, ModuleSimpleGridAscii):
         """
         Set members using inventory.
         """
-        try:
-            Component._configure(self)
-            self.filename = self.inventory.filename
-        except ValueError, err:
-            aliases = ", ".join(self.aliases)
-            raise ValueError("Error while configuring spatial database reader "
-                             "(%s):\n%s" % (aliases, err.message))
+        Component._configure(self)
 
     def _createModuleObj(self):
         """
@@ -141,6 +134,12 @@ class SimpleGridAscii(Component, ModuleSimpleGridAscii):
 
 
 # FACTORIES ////////////////////////////////////////////////////////////
+
+def createWriter(filename):
+    writer = SimpleGridAscii()
+    writer.inventory.filename = filename
+    return writer
+
 
 def simplegrid_io():
     """

--- a/spatialdata/spatialdb/SimpleGridDB.py
+++ b/spatialdata/spatialdb/SimpleGridDB.py
@@ -28,6 +28,10 @@ def validateFilename(value):
     """
     if 0 == len(value):
         raise ValueError("Name of SimpleGridDB file must be specified.")
+    try:
+        fin = open(value, "r")
+    except IOError:
+        raise IOError("Spatial database file '{}' not found.".format(value))
     return value
 
 

--- a/spatialdata/spatialdb/SimpleIO.py
+++ b/spatialdata/spatialdb/SimpleIO.py
@@ -27,6 +27,10 @@ def validateFilename(value):
     """
     if 0 == len(value):
         raise ValueError("Filename for spatial database not specified.")
+    try:
+        fin = open(value, "r")
+    except IOError:
+        raise IOError("Spatial database file '{}' not found.".format(value))
     return value
 
 

--- a/spatialdata/spatialdb/SimpleIOAscii.py
+++ b/spatialdata/spatialdb/SimpleIOAscii.py
@@ -75,7 +75,6 @@ class SimpleIOAscii(SimpleIO, ModuleSimpleIOAscii):
         dbData.setNames(names)
         dbData.setUnits(units)
 
-        ModuleSimpleIOAscii.setFilename(self, self.filename)
         ModuleSimpleIOAscii.write(self, dbData, data['coordsys'])
 
     # PRIVATE METHODS ////////////////////////////////////////////////////
@@ -91,6 +90,12 @@ class SimpleIOAscii(SimpleIO, ModuleSimpleIOAscii):
 
 
 # FACTORIES ////////////////////////////////////////////////////////////
+
+def createWriter(filename):
+    writer = SimpleIOAscii()
+    writer.setFilename(filename)
+    return writer
+
 
 def simpledb_io():
     """

--- a/spatialdata/spatialdb/TimeHistory.py
+++ b/spatialdata/spatialdb/TimeHistory.py
@@ -87,6 +87,13 @@ class TimeHistory(Component, ModuleTimeHistory):
 
 # FACTORIES ////////////////////////////////////////////////////////////
 
+def createWriter(filename, label="Time history writer"):
+    writer = TimeHistory()
+    writer.setLabel(label)
+    writer.setFilename(filename)
+    return writer
+
+
 def temporal_database():
     """
     Factory associated with TimeHistory.

--- a/spatialdata/spatialdb/TimeHistory.py
+++ b/spatialdata/spatialdb/TimeHistory.py
@@ -22,6 +22,19 @@ from pyre.components.Component import Component
 from spatialdb import TimeHistory as ModuleTimeHistory
 
 
+def validateFilename(value):
+    """
+    Validate filename.
+    """
+    if 0 == len(value):
+        raise ValueError("Name of SimpleGridDB file must be specified.")
+    try:
+        fin = open(value, "r")
+    except IOError:
+        raise IOError("Spatial database file '{}' not found.".format(value))
+    return value
+
+
 class TimeHistory(Component, ModuleTimeHistory):
     """
     Python object for time history dependence with spatial databases.
@@ -43,7 +56,7 @@ class TimeHistory(Component, ModuleTimeHistory):
     label = pyre.inventory.str("label", default="temporal database")
     label.meta['tip'] = "Label for time history."
 
-    filename = pyre.inventory.str("filename", default="timehistory.timedb")
+    filename = pyre.inventory.str("filename", default="timehistory.timedb", validator=validateFilename)
     filename.meta['tip'] = "Name of file for time history."
 
     # PUBLIC METHODS /////////////////////////////////////////////////////

--- a/spatialdata/spatialdb/generator/GenSimpleDBApp.py
+++ b/spatialdata/spatialdb/generator/GenSimpleDBApp.py
@@ -31,6 +31,15 @@ def valueFactory(name):
     return facility(name, family="database_value", factory=Value)
 
 
+def validateFilename(value):
+    """
+    Validate filename.
+    """
+    if 0 == len(value):
+        raise ValueError("Filename for spatial database not specified.")
+    return value
+
+
 # ----------------------------------------------------------------------------------------------------------------------
 class SingleValue(Component):
     """
@@ -85,9 +94,8 @@ class GenSimpleDBApp(Script):
     values = pyre.inventory.facilityArray("values", itemFactory=valueFactory, factory=SingleValue)
     values.meta['tip'] = "Values in database."
 
-    from spatialdata.spatialdb.SimpleIOAscii import SimpleIOAscii
-    iohandler = pyre.inventory.facility("iohandler", family="simpledb_io", factory=SimpleIOAscii)
-    iohandler.meta['tip'] = "Object for writing database."
+    filename = pyre.inventory.str("filename", default="", validator=validateFilename)
+    filename.meta['tip'] = "Filename for generated ASCII SimpleDB."
 
     # PUBLIC METHODS /////////////////////////////////////////////////////
 
@@ -101,6 +109,8 @@ class GenSimpleDBApp(Script):
         """
         Application driver.
         """
+        from spatialdata.spatialdb.SimpleIOAscii import createWriter
+
         self._info.log("Reading geometry.")
         self.geometry.read()
         points = self.geometry.vertices
@@ -119,6 +129,7 @@ class GenSimpleDBApp(Script):
                 'data': value.calculate(points, coordsys),
             })
         self._info.log("Writing database.")
-        self.iohandler.write(data)
+        writer = createWriter(self.filename)
+        writer.write(data)
 
 # End of file

--- a/tests/pytests/spatialdb/TestSimpleGridDB.py
+++ b/tests/pytests/spatialdb/TestSimpleGridDB.py
@@ -89,7 +89,7 @@ class TestSimpleGridDB(unittest.TestCase):
             self.assertAlmostEqual(vE, v, 6)
 
     def test_io_3d(self):
-        from spatialdata.spatialdb.SimpleGridAscii import SimpleGridAscii
+        from spatialdata.spatialdb.SimpleGridAscii import createWriter
 
         filename = "data/gridio3d.spatialdb"
         x = numpy.array([-2.0, 0.0, 3.0], dtype=numpy.float64)
@@ -123,9 +123,7 @@ class TestSimpleGridDB(unittest.TestCase):
 
         cs = CSCart()
 
-        writer = SimpleGridAscii()
-        writer.inventory.filename = filename
-        writer._configure()
+        writer = createWriter(filename)
         writer.write({'points': points,
                       'x': x,
                       'y': y,
@@ -176,7 +174,7 @@ class TestSimpleGridDB(unittest.TestCase):
             self.assertAlmostEqual(vE, v, 6)
 
     def test_io_2d(self):
-        from spatialdata.spatialdb.SimpleGridAscii import SimpleGridAscii
+        from spatialdata.spatialdb.SimpleGridAscii import createWriter
 
         filename = "data/gridio2d.spatialdb"
         x = numpy.array([-2.0, 0.0, 3.0], dtype=numpy.float64)
@@ -197,9 +195,7 @@ class TestSimpleGridDB(unittest.TestCase):
         cs.inventory.spaceDim = 2
         cs._configure()
 
-        writer = SimpleGridAscii()
-        writer.inventory.filename = filename
-        writer._configure()
+        writer = createWriter(filename)
         writer.write({'points': points,
                       'x': x,
                       'y': y,
@@ -250,7 +246,7 @@ class TestSimpleGridDB(unittest.TestCase):
 # ----------------------------------------------------------------------------------------------------------------------
 if __name__ == '__main__':
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestSimpleDB))
+    suite.addTest(unittest.makeSuite(TestSimpleGridDB))
     unittest.TextTestRunner(verbosity=2).run(suite)
 
 

--- a/tests/pytests/spatialdb/TestSimpleIOAscii.py
+++ b/tests/pytests/spatialdb/TestSimpleIOAscii.py
@@ -51,10 +51,8 @@ class TestSimpleIOAscii(unittest.TestCase):
         errE = [0, 0, 0]
 
         # Write database
-        from spatialdata.spatialdb.SimpleIOAscii import SimpleIOAscii
-        writer = SimpleIOAscii()
-        writer.inventory.filename = filename
-        writer._configure()
+        from spatialdata.spatialdb.SimpleIOAscii import createWriter
+        writer = createWriter(filename)
         writer.write(data)
 
         # Test write using query

--- a/tests/pytests/spatialdb/gensimpledb.cfg
+++ b/tests/pytests/spatialdb/gensimpledb.cfg
@@ -79,4 +79,4 @@ db.iohandler.filename = data/gen1Din2D_two_divide.spatialdb
 # io
 # ----------------------------------------------------------------------
 [gensimpledb]
-iohandler.filename = data/gen1Din2D.spatialdb
+filename = data/gen1Din2D.spatialdb


### PR DESCRIPTION
Verify that we can open sptial database files in validator. This 
generates an error upon cnfiguration rather than open().