### PR TITLE
Migrate code for Python 2/3 compatibility

### DIFF
--- a/spatialdata/geocoords/CSCart.py
+++ b/spatialdata/geocoords/CSCart.py
@@ -17,8 +17,8 @@
 # @brief Python manager for Cartesian coordinate systems.
 #
 
-from CoordSys import CoordSys
-from geocoords import CSCart as ModuleCSCart
+from .CoordSys import CoordSys
+from .geocoords import CSCart as ModuleCSCart
 
 # CSCart class
 

--- a/spatialdata/geocoords/CSGeo.py
+++ b/spatialdata/geocoords/CSGeo.py
@@ -18,8 +18,8 @@
 #
 # Factory: coordsys.
 
-from CoordSys import CoordSys
-from geocoords import CSGeo as ModuleCSGeo
+from .CoordSys import CoordSys
+from .geocoords import CSGeo as ModuleCSGeo
 
 
 class CSGeo(CoordSys, ModuleCSGeo):

--- a/spatialdata/geocoords/Converter.py
+++ b/spatialdata/geocoords/Converter.py
@@ -28,7 +28,7 @@ def convert(coords, csDest, csSrc):
               "coordinate systems must match." % (csSrc.getSpaceDim(), csDest.getSpaceDim())
         raise ValueError(msg)
 
-    import geocoords
+    from . import geocoords
     converter = geocoords.Converter()
     converter.convert(coords, csDest, csSrc)
     return

--- a/spatialdata/spatialdb/CompositeDB.py
+++ b/spatialdata/spatialdb/CompositeDB.py
@@ -18,8 +18,8 @@
 #
 # Factory: spatial_database
 
-from SpatialDBObj import SpatialDBObj
-from spatialdb import CompositeDB as ModuleCompositeDB
+from .SpatialDBObj import SpatialDBObj
+from .spatialdb import CompositeDB as ModuleCompositeDB
 
 
 class CompositeDB(SpatialDBObj, ModuleCompositeDB):
@@ -47,7 +47,7 @@ class CompositeDB(SpatialDBObj, ModuleCompositeDB):
     namesB = pyre.inventory.list("values_B", default=[])
     namesB.meta['tip'] = "Names of values to query with database B."
 
-    from UniformDB import UniformDB
+    from .UniformDB import UniformDB
     dbA = pyre.inventory.facility("db_A", factory=UniformDB, family="spatial_database")
     dbA.meta['tip'] = "Spatial database A."
 

--- a/spatialdata/spatialdb/CompositeDB.py
+++ b/spatialdata/spatialdb/CompositeDB.py
@@ -85,15 +85,11 @@ class CompositeDB(SpatialDBObj, ModuleCompositeDB):
         Validate parameters.
         """
         if (0 == len(data.namesA)):
-            raise ValueError, \
-                "Error in spatial database '%s'\n" \
-                "Names of values to query in database A not set." \
-                % self.label
+            raise ValueError("Error in spatial database '%s'\n"
+                             "Names of values to query in database A not set." % self.label)
         if (0 == len(data.namesB)):
-            raise ValueError, \
-                "Error in spatial database '%s'\n" \
-                "Names of values to query in database B not set." \
-                % self.label
+            raise ValueError("Error in spatial database '%s'\n"
+                             "Names of values to query in database B not set." % self.label)
         return
 
 

--- a/spatialdata/spatialdb/GravityField.py
+++ b/spatialdata/spatialdb/GravityField.py
@@ -71,7 +71,7 @@ class GravityField(SpatialDBObj, ModuleGravityField):
         """
         SpatialDBObj._configure(self)
         self._validateParameters(self.inventory)
-        dir = map(float, self.gravityDir)
+        dir = list(map(float, self.gravityDir))
         ModuleGravityField.setGravityDir(self, dir[0], dir[1], dir[2])
         ModuleGravityField.setGravityAcc(self, self.acceleration.value)
 
@@ -88,7 +88,7 @@ class GravityField(SpatialDBObj, ModuleGravityField):
         if (len(params.gravityDir) != 3):
             raise ValueError("Gravity direction must be a 3 component list or tuple.")
         try:
-            dirFloat = map(float, params.gravityDir)
+            dirFloat = list(map(float, params.gravityDir))
         except:
             raise ValueError("Gravity direction must contain floating point values.")
 

--- a/spatialdata/spatialdb/GravityField.py
+++ b/spatialdata/spatialdb/GravityField.py
@@ -18,8 +18,8 @@
 #
 # Factory: spatial_database
 
-from SpatialDBObj import SpatialDBObj
-from spatialdb import GravityField as ModuleGravityField
+from .SpatialDBObj import SpatialDBObj
+from .spatialdb import GravityField as ModuleGravityField
 
 
 class GravityField(SpatialDBObj, ModuleGravityField):

--- a/spatialdata/spatialdb/SCECCVMH.py
+++ b/spatialdata/spatialdb/SCECCVMH.py
@@ -18,8 +18,8 @@
 #
 # Factory: spatial_database
 
-from SpatialDBObj import SpatialDBObj
-from spatialdb import SCECCVMH as ModuleSCECCVMH
+from .SpatialDBObj import SpatialDBObj
+from .spatialdb import SCECCVMH as ModuleSCECCVMH
 
 
 class SCECCVMH(SpatialDBObj, ModuleSCECCVMH):

--- a/spatialdata/spatialdb/SimpleDB.py
+++ b/spatialdata/spatialdb/SimpleDB.py
@@ -18,8 +18,8 @@
 #
 # Factory: spatial_database
 
-from SpatialDBObj import SpatialDBObj
-from spatialdb import SimpleDB as ModuleSimpleDB
+from .SpatialDBObj import SpatialDBObj
+from .spatialdb import SimpleDB as ModuleSimpleDB
 
 
 class SimpleDB(SpatialDBObj, ModuleSimpleDB):
@@ -43,7 +43,7 @@ class SimpleDB(SpatialDBObj, ModuleSimpleDB):
     queryType.validator = pyre.inventory.choice(["nearest", "linear"])
     queryType.meta['tip'] = "Type of query to perform."
 
-    from SimpleIOAscii import SimpleIOAscii
+    from .SimpleIOAscii import SimpleIOAscii
     iohandler = pyre.inventory.facility("iohandler", family="simpledb_io",
                                         factory=SimpleIOAscii)
     iohandler.meta['tip'] = "I/O handler for database."

--- a/spatialdata/spatialdb/SimpleGridAscii.py
+++ b/spatialdata/spatialdb/SimpleGridAscii.py
@@ -20,7 +20,7 @@
 # Factory: simplegrid_io
 
 from pyre.components.Component import Component
-from spatialdb import SimpleGridAscii as ModuleSimpleGridAscii
+from .spatialdb import SimpleGridAscii as ModuleSimpleGridAscii
 
 
 def validateFilename(value):
@@ -102,7 +102,7 @@ class SimpleGridAscii(Component, ModuleSimpleGridAscii):
                 raise ValueError("Number of locations (%d) does not match coordinate dimensions (%d, %d, %d)." %
                                  (numLocs, numX, numY, numZ))
 
-        from SimpleGridDB import SimpleGridDB
+        from .SimpleGridDB import SimpleGridDB
         db = SimpleGridDB()
         db.setLabel("Temporary SimpleGridDB for writing")
         db.setFilename(self.filename)

--- a/spatialdata/spatialdb/SimpleGridDB.py
+++ b/spatialdata/spatialdb/SimpleGridDB.py
@@ -18,8 +18,8 @@
 #
 # Factory: spatial_database
 
-from SpatialDBObj import SpatialDBObj
-from spatialdb import SimpleGridDB as ModuleSimpleGridDB
+from .SpatialDBObj import SpatialDBObj
+from .spatialdb import SimpleGridDB as ModuleSimpleGridDB
 
 
 def validateFilename(value):

--- a/spatialdata/spatialdb/SimpleIOAscii.py
+++ b/spatialdata/spatialdb/SimpleIOAscii.py
@@ -18,8 +18,8 @@
 #
 # Factory: simpledb_io
 
-from SimpleIO import SimpleIO
-from spatialdb import SimpleIOAscii as ModuleSimpleIOAscii
+from .SimpleIO import SimpleIO
+from .spatialdb import SimpleIOAscii as ModuleSimpleIOAscii
 
 
 class SimpleIOAscii(SimpleIO, ModuleSimpleIOAscii):
@@ -67,7 +67,7 @@ class SimpleIOAscii(SimpleIO, ModuleSimpleIOAscii):
             values[:, i] = value['data'][:]
             i += 1
 
-        from spatialdb import SimpleDBData
+        from .spatialdb import SimpleDBData
         dbData = SimpleDBData()
         dbData.allocate(numLocs, numValues, spaceDim, dataDim)
         dbData.setCoordinates(data['points'])

--- a/spatialdata/spatialdb/SpatialDBObj.py
+++ b/spatialdata/spatialdb/SpatialDBObj.py
@@ -19,7 +19,7 @@
 # Factory: spatial_database
 
 from pyre.components.Component import Component
-from spatialdb import SpatialDB as ModuleSpatialDB
+from .spatialdb import SpatialDB as ModuleSpatialDB
 
 
 def validateLabel(value):

--- a/spatialdata/spatialdb/TimeHistory.py
+++ b/spatialdata/spatialdb/TimeHistory.py
@@ -19,7 +19,7 @@
 # Factory: temporal_database
 
 from pyre.components.Component import Component
-from spatialdb import TimeHistory as ModuleTimeHistory
+from .spatialdb import TimeHistory as ModuleTimeHistory
 
 
 def validateFilename(value):

--- a/spatialdata/spatialdb/TimeHistoryIO.py
+++ b/spatialdata/spatialdb/TimeHistoryIO.py
@@ -21,7 +21,7 @@ def write(time, amplitude, units, filename):
     """
     Write time history file.
     """
-    import spatialdb
+    from . import spatialdb
     spatialdb.TimeHistoryIO.write(time, amplitude, units, filename)
     return
 

--- a/spatialdata/spatialdb/UniformDB.py
+++ b/spatialdata/spatialdb/UniformDB.py
@@ -18,8 +18,8 @@
 #
 # Factory: spatial_database
 
-from SpatialDBObj import SpatialDBObj
-from spatialdb import UniformDB as ModuleUniformDB
+from .SpatialDBObj import SpatialDBObj
+from .spatialdb import UniformDB as ModuleUniformDB
 
 
 class UniformDB(SpatialDBObj, ModuleUniformDB):

--- a/spatialdata/spatialdb/UserFunctionDB.py
+++ b/spatialdata/spatialdb/UserFunctionDB.py
@@ -20,8 +20,8 @@
 #
 # Factory: spatial_database
 
-from SpatialDBObj import SpatialDBObj
-from spatialdb import UserFunctionDB as ModuleUserFunctionDB
+from .SpatialDBObj import SpatialDBObj
+from .spatialdb import UserFunctionDB as ModuleUserFunctionDB
 
 
 class UserFunctionDB(SpatialDBObj, ModuleUserFunctionDB):

--- a/spatialdata/spatialdb/generator/GenSimpleDBApp.py
+++ b/spatialdata/spatialdb/generator/GenSimpleDBApp.py
@@ -20,6 +20,8 @@
 from pyre.applications.Script import Script
 from pyre.components.Component import Component
 
+from .Value import Value
+
 
 # ----------------------------------------------------------------------------------------------------------------------
 def valueFactory(name):
@@ -27,7 +29,6 @@ def valueFactory(name):
     Factory for values.
     """
     from pyre.inventory import facility
-    from Value import Value
     return facility(name, family="database_value", factory=Value)
 
 
@@ -55,8 +56,6 @@ class SingleValue(Component):
     """
 
     import pyre.inventory
-
-    from Value import Value
     dbValue = pyre.inventory.facility("value", family="database_value", factory=Value)
     dbValue.meta['tip'] = "Value in spatial database."
 
@@ -87,7 +86,7 @@ class GenSimpleDBApp(Script):
 
     import pyre.inventory
 
-    from Geometry import Geometry
+    from .Geometry import Geometry
     geometry = pyre.inventory.facility("geometry", family="geometry", factory=Geometry)
     geometry.meta['tip'] = "Object defining geometry of region covered by database."
 

--- a/spatialdata/spatialdb/generator/Value.py
+++ b/spatialdata/spatialdb/generator/Value.py
@@ -17,9 +17,11 @@
 #
 # Factory: database_value
 
+import numpy
+
 from pyre.components.Component import Component
 
-import numpy
+from .Shaper import Shaper
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -28,7 +30,6 @@ def shaperFactory(name):
     Factory for shapers.
     """
     from pyre.inventory import facility
-    from Shaper import Shaper
     return facility(name, family="shaper", factory=Shaper)
 
 
@@ -47,8 +48,6 @@ class SingleShaper(Component):
     """
 
     import pyre.inventory
-
-    from Shaper import Shaper
     valueShaper = pyre.inventory.facility("shaper", family="shaper", factory=Shaper)
     valueShaper.meta['tip'] = "Shaper for database value."
 

--- a/spatialdata/units/NondimElasticDynamic.py
+++ b/spatialdata/units/NondimElasticDynamic.py
@@ -18,7 +18,7 @@
 #
 # Factory: nondimensional
 
-from Nondimensional import Nondimensional
+from .Nondimensional import Nondimensional
 
 
 class NondimElasticDynamic(Nondimensional):

--- a/spatialdata/units/NondimElasticQuasistatic.py
+++ b/spatialdata/units/NondimElasticQuasistatic.py
@@ -18,7 +18,7 @@
 #
 # Factory: nondimensional
 
-from Nondimensional import Nondimensional
+from .Nondimensional import Nondimensional
 
 
 class NondimElasticQuasistatic(Nondimensional):

--- a/spatialdata/units/Nondimensional.py
+++ b/spatialdata/units/Nondimensional.py
@@ -18,7 +18,7 @@
 # Factory: nondimensional
 
 from pyre.components.Component import Component
-from units import Nondimensional as ModuleNondimensional
+from .units import Nondimensional as ModuleNondimensional
 
 
 class Nondimensional(Component, ModuleNondimensional):

--- a/templates/spatialdb/UniformVelModel.py
+++ b/templates/spatialdb/UniformVelModel.py
@@ -14,129 +14,128 @@
 # ----------------------------------------------------------------------
 #
 
-## @brief Python object associated with the C++ UniformVelModel
-## object. This objects provides a Pyre interface to the C++ object. 
+# @brief Python object associated with the C++ UniformVelModel
+# object. This objects provides a Pyre interface to the C++ object.
 ##
-## Factory: spatial_database
+# Factory: spatial_database
 
 from spatialdata.spatialdb.SpatialDBObj import SpatialDBObj
-from spatialdbcontrib import UniformVelModel as ModuleUniformVelModel
+from .spatialdbcontrib import UniformVelModel as ModuleUniformVelModel
 
 # UniformVelModel class
+
+
 class UniformVelModel(SpatialDBObj, ModuleUniformVelModel):
-  """
-  Python object associated with the C++ UniformVelModel object. This
-  objects provides a Pyre interface to the C++ object. It inherits
-  from the generic SpatialDBObj and the UniformVelModel SWIG module
-  object. This insures that this object has all of the SpatialDBObj
-  Pyre properties and facilities and functions and calls to the
-  underlying C++ code are passed onto the SWIG Python module.
-
-  Factory: spatial_database
-  """
-
-  # INVENTORY //////////////////////////////////////////////////////////
-
-  class Inventory(SpatialDBObj.Inventory):
     """
-    Python object for managing UniformVelModel Pyre facilities and properties.
+    Python object associated with the C++ UniformVelModel object. This
+    objects provides a Pyre interface to the C++ object. It inherits
+    from the generic SpatialDBObj and the UniformVelModel SWIG module
+    object. This insures that this object has all of the SpatialDBObj
+    Pyre properties and facilities and functions and calls to the
+    underlying C++ code are passed onto the SWIG Python module.
 
-    ## \b Properties
-    ## @li \b vs S wave speed.
-    ## @li \b vp P wave speed.
-    ## @li \b density Density.
-    ##
-    ## \b Facilities
-    ## @li none
+    Factory: spatial_database
     """
 
-    import pyre.inventory
+    # INVENTORY //////////////////////////////////////////////////////////
 
-    # Units used in properties
-    from pyre.units.time import s
-    from pyre.units.length import km,m
-    from pyre.units.mass import kg
+    class Inventory(SpatialDBObj.Inventory):
+        """
+        Python object for managing UniformVelModel Pyre facilities and properties.
 
-    # Pyre properties have the form
-    #
-    # VARIABLE = pyre.inventory.TYPE("CFG_NAME", default=DEFAULT_VALUE)
-    # VARIABLE.meta['tip'] = "HELP STRING"
-    #
-    # where VARIABLE is a variable used to refer to the Pyre property,
-    # TYPE of the type of property (dimensional, str, float, int,
-    # etc), CFG_NAME is the name used in the Pyre .cfg files and the
-    # command line, and DEFAULT_VALUE is the default value.
-    #
-    # When a Pyre property is a dimensional scalar quantity, use the
-    # dimensional type for properties and Pyre will automatically
-    # check to make sure user-specified quantities have compatible
-    # units and convert the value to SI units.
-    #
-    # The help string will be printed when the user uses the command
-    # line arugments --FULL_COMPONENT_NAME.help-properties or
-    # --FULL_COMPONENT.help-components. See the PyLith manual chapter
-    # "Running PyLith" for more information regarding getting help
-    # using command line arguments.
-    #
-    # Create a Pyre property named vs with a default value of 2.6 km/s.
-    vs = pyre.inventory.dimensional("vs", default=2.6*km/s)
-    vs.meta['tip'] = "S wave speed."
+        ## \b Properties
+        ## @li \b vs S wave speed.
+        ## @li \b vp P wave speed.
+        ## @li \b density Density.
+        ##
+        ## \b Facilities
+        ## @li none
+        """
 
-    # Create a Pyre property named vp with a default value of 4.5 km/s.
-    vp = pyre.inventory.dimensional("vp", default=4.5*km/s)
-    vp.meta['tip'] = "P wave speed."
+        import pyre.inventory
 
-    # Create a Pyre property named density with a default value of 2500 kg/m**3.
-    density = pyre.inventory.dimensional("density", default=2.5e+3*kg/m**3)
-    density.meta['tip'] = "Density."
+        # Units used in properties
+        from pyre.units.time import s
+        from pyre.units.length import km, m
+        from pyre.units.mass import kg
 
+        # Pyre properties have the form
+        #
+        # VARIABLE = pyre.inventory.TYPE("CFG_NAME", default=DEFAULT_VALUE)
+        # VARIABLE.meta['tip'] = "HELP STRING"
+        #
+        # where VARIABLE is a variable used to refer to the Pyre property,
+        # TYPE of the type of property (dimensional, str, float, int,
+        # etc), CFG_NAME is the name used in the Pyre .cfg files and the
+        # command line, and DEFAULT_VALUE is the default value.
+        #
+        # When a Pyre property is a dimensional scalar quantity, use the
+        # dimensional type for properties and Pyre will automatically
+        # check to make sure user-specified quantities have compatible
+        # units and convert the value to SI units.
+        #
+        # The help string will be printed when the user uses the command
+        # line arugments --FULL_COMPONENT_NAME.help-properties or
+        # --FULL_COMPONENT.help-components. See the PyLith manual chapter
+        # "Running PyLith" for more information regarding getting help
+        # using command line arguments.
+        #
+        # Create a Pyre property named vs with a default value of 2.6 km/s.
+        vs = pyre.inventory.dimensional("vs", default=2.6 * km / s)
+        vs.meta['tip'] = "S wave speed."
 
-  # PUBLIC METHODS /////////////////////////////////////////////////////
+        # Create a Pyre property named vp with a default value of 4.5 km/s.
+        vp = pyre.inventory.dimensional("vp", default=4.5 * km / s)
+        vp.meta['tip'] = "P wave speed."
 
-  def __init__(self, name="uniformvelmodel"):
-    """
-    Constructor. This function is called automatically when the Python
-    UniformVelModel object is created.
-    """
-    SpatialDBObj.__init__(self, name)
-    return
+        # Create a Pyre property named density with a default value of 2500 kg/m**3.
+        density = pyre.inventory.dimensional("density", default=2.5e+3 * kg / m**3)
+        density.meta['tip'] = "Density."
 
+    # PUBLIC METHODS /////////////////////////////////////////////////////
 
-  # PRIVATE METHODS ////////////////////////////////////////////////////
+    def __init__(self, name="uniformvelmodel"):
+        """
+        Constructor. This function is called automatically when the Python
+        UniformVelModel object is created.
+        """
+        SpatialDBObj.__init__(self, name)
+        return
 
-  def _configure(self):
-    """
-    Set members based on inventory. This function is called
-    automatically when the component is setup.
-    """
-    SpatialDBObj._configure(self) # Call parent function.
-    
-    # Transfer inventory to C++ object
-    ModuleUniformVelModel.vs(self, self.inventory.vs.value)
-    ModuleUniformVelModel.vp(self, self.inventory.vp.value)
-    ModuleUniformVelModel.density(self, self.inventory.density.value)
-    return
+    # PRIVATE METHODS ////////////////////////////////////////////////////
 
+    def _configure(self):
+        """
+        Set members based on inventory. This function is called
+        automatically when the component is setup.
+        """
+        SpatialDBObj._configure(self)  # Call parent function.
 
-  def _createModuleObj(self):
-    """
-    Create handle to C++ object. This function is called by the
-    generic SpatialDBObj constructor. The name cannot be changed and
-    no arguments can be added.
-    """
-    # Create the SWIG module object to provide access to the C++ object.
-    ModuleUniformVelModel.__init__(self)
-    return
+        # Transfer inventory to C++ object
+        ModuleUniformVelModel.vs(self, self.inventory.vs.value)
+        ModuleUniformVelModel.vp(self, self.inventory.vp.value)
+        ModuleUniformVelModel.density(self, self.inventory.density.value)
+        return
+
+    def _createModuleObj(self):
+        """
+        Create handle to C++ object. This function is called by the
+        generic SpatialDBObj constructor. The name cannot be changed and
+        no arguments can be added.
+        """
+        # Create the SWIG module object to provide access to the C++ object.
+        ModuleUniformVelModel.__init__(self)
+        return
 
 
 # FACTORIES ////////////////////////////////////////////////////////////
 
 # Factory used when setting UniformVelModel to a Pyre 'spatial_database' facility.
 def spatial_database():
-  """
-  Factory associated with UniformVelModel.
-  """
-  return UniformVelModel()
+    """
+    Factory associated with UniformVelModel.
+    """
+    return UniformVelModel()
 
 
-# End of file 
+# End of file

--- a/templates/spatialdb/tests/TestUniformVelModel.py
+++ b/templates/spatialdb/tests/TestUniformVelModel.py
@@ -54,7 +54,7 @@ class TestUniformVelModel(unittest.TestCase):
     data = numpy.zeros(dataE.shape, dtype=numpy.float64)
     err = []
     nlocs = locs.shape[0]
-    for i in xrange(nlocs):
+    for i in range(nlocs):
       e = db.query(data[i,:], locs[i,:], self._csQ)
       err.append(e)
     db.close()    
@@ -87,7 +87,7 @@ class TestUniformVelModel(unittest.TestCase):
     data = numpy.zeros(dataE.shape, dtype=numpy.float64)
     err = []
     nlocs = locs.shape[0]
-    for i in xrange(nlocs):
+    for i in range(nlocs):
       e = db.query(data[i,:], locs[i,:], self._csQ)
       err.append(e)
     db.close()    

--- a/templates/spatialdb/tests/testcontrib.py
+++ b/templates/spatialdb/tests/testcontrib.py
@@ -16,21 +16,24 @@
 
 import unittest
 
+
 def suite():
 
-  suite = unittest.TestSuite()
+    suite = unittest.TestSuite()
 
-  from TestUniformVelModel import TestUniformVelModel
-  suite.addTest(unittest.makeSuite(TestUniformVelModel))
+    from TestUniformVelModel import TestUniformVelModel
+    suite.addTest(unittest.makeSuite(TestUniformVelModel))
 
-  return suite
+    return suite
+
 
 def main():
-  unittest.TextTestRunner(verbosity=2).run(suite())
-  return
+    unittest.TextTestRunner(verbosity=2).run(suite())
+    return
+
 
 if __name__ == '__main__':
-  main()
-  
+    main()
 
-# End of file 
+
+# End of file

--- a/tests/pytests/spatialdb/TestCompositeDB.py
+++ b/tests/pytests/spatialdb/TestCompositeDB.py
@@ -63,7 +63,7 @@ class TestCompositeDB(unittest.TestCase):
         data = numpy.zeros(dataE.shape, dtype=numpy.float64)
         err = []
         nlocs = locs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(data[i, :], locs[i, :], cs)
             err.append(e)
         db.close()

--- a/tests/pytests/spatialdb/TestGenSimpleDBApp.py
+++ b/tests/pytests/spatialdb/TestGenSimpleDBApp.py
@@ -54,7 +54,7 @@ class TestGenSimpleDBApp(unittest.TestCase):
         data = numpy.zeros(dataE.shape, dtype=numpy.float64)
         err = []
         nlocs = qlocs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(data[i, :], qlocs[i, :], cs)
             err.append(e)
         db.close()

--- a/tests/pytests/spatialdb/TestGravityField.py
+++ b/tests/pytests/spatialdb/TestGravityField.py
@@ -39,7 +39,7 @@ class TestGravityField(unittest.TestCase):
         data = numpy.zeros(dataE.shape, dtype=numpy.float64)
         err = []
         nlocs = locs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(data[i, :], locs[i, :], cs)
             err.append(e)
         db.close()

--- a/tests/pytests/spatialdb/TestSimpleDB.py
+++ b/tests/pytests/spatialdb/TestSimpleDB.py
@@ -45,7 +45,7 @@ class TestSimpleDB(unittest.TestCase):
         data = numpy.zeros(dataE.shape, dtype=numpy.float64)
         err = []
         nlocs = locs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(data[i, :], locs[i, :], cs)
             err.append(e)
         db.close()

--- a/tests/pytests/spatialdb/TestSimpleGridDB.py
+++ b/tests/pytests/spatialdb/TestSimpleGridDB.py
@@ -47,7 +47,7 @@ class TestSimpleGridDB(unittest.TestCase):
         data = numpy.zeros(dataE.shape, dtype=numpy.float64)
         err = []
         nlocs = locs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(data[i, :], locs[i, :], cs)
             err.append(e)
         db.close()
@@ -158,7 +158,7 @@ class TestSimpleGridDB(unittest.TestCase):
         data = numpy.zeros(dataE.shape, dtype=numpy.float64)
         err = []
         nlocs = locs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(data[i, :], locs[i, :], cs)
             err.append(e)
         db.close()
@@ -227,7 +227,7 @@ class TestSimpleGridDB(unittest.TestCase):
         data = numpy.zeros(dataE.shape, dtype=numpy.float64)
         err = []
         nlocs = locs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(data[i, :], locs[i, :], cs)
             err.append(e)
         db.close()

--- a/tests/pytests/spatialdb/TestSimpleIOAscii.py
+++ b/tests/pytests/spatialdb/TestSimpleIOAscii.py
@@ -69,7 +69,7 @@ class TestSimpleIOAscii(unittest.TestCase):
         vals = numpy.zeros(valsE.shape, dtype=numpy.float64)
         err = []
         nlocs = qlocs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(vals[i, :], qlocs[i, :], cs)
             err.append(e)
         db.close()

--- a/tests/pytests/spatialdb/TestTimeHistory.py
+++ b/tests/pytests/spatialdb/TestTimeHistory.py
@@ -38,7 +38,7 @@ class TestTimeHistory(unittest.TestCase):
         amplitude = numpy.zeros((nlocs,), dtype=numpy.float64)
         err = numpy.zeros((nlocs,), dtype=numpy.int32)
 
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             (e, amplitude[i]) = th.query(timeQ[i])
             err[i] = e
         th.close()

--- a/tests/pytests/spatialdb/TestTimeHistoryIO.py
+++ b/tests/pytests/spatialdb/TestTimeHistoryIO.py
@@ -50,7 +50,7 @@ class TestTimeHistoryIO(unittest.TestCase):
         iline = 0
         for (lineE, line) in zip(linesE, lines):
             if lineE != line:
-                print "Error found in line %d in file '%s' is incorrect." % (iline, filename)
+                print("Error found in line %d in file '%s' is incorrect." % (iline, filename))
                 self.failIf(True)
             iline += 1
 

--- a/tests/pytests/spatialdb/TestUniformDB.py
+++ b/tests/pytests/spatialdb/TestUniformDB.py
@@ -44,7 +44,7 @@ class TestUniformDB(unittest.TestCase):
         data = numpy.zeros(dataE.shape, dtype=numpy.float64)
         err = []
         nlocs = locs.shape[0]
-        for i in xrange(nlocs):
+        for i in range(nlocs):
             e = db.query(data[i, :], locs[i, :], cs)
             err.append(e)
         db.close()

--- a/tests/pytests/units/test_units.py
+++ b/tests/pytests/units/test_units.py
@@ -18,37 +18,38 @@ from spatialdata.utils.UnitTestApp import UnitTestApp
 
 import unittest
 
+
 class TestApp(UnitTestApp):
-  """Test application.
-  """
-
-  def __init__(self):
-    """Constructor.
+    """Test application.
     """
-    UnitTestApp.__init__(self)
-    return
 
-  def _suite(self):
-    """Setup the test suite.
-    """
-    suite = unittest.TestSuite()
+    def __init__(self):
+        """Constructor.
+        """
+        UnitTestApp.__init__(self)
+        return
 
-    from TestNondimensional import TestNondimensional
-    suite.addTest(unittest.makeSuite(TestNondimensional))
+    def _suite(self):
+        """Setup the test suite.
+        """
+        suite = unittest.TestSuite()
 
-    from TestNondimElasticQuasistatic import TestNondimElasticQuasistatic
-    suite.addTest(unittest.makeSuite(TestNondimElasticQuasistatic))
+        from TestNondimensional import TestNondimensional
+        suite.addTest(unittest.makeSuite(TestNondimensional))
 
-    from TestNondimElasticDynamic import TestNondimElasticDynamic
-    suite.addTest(unittest.makeSuite(TestNondimElasticDynamic))
+        from TestNondimElasticQuasistatic import TestNondimElasticQuasistatic
+        suite.addTest(unittest.makeSuite(TestNondimElasticQuasistatic))
 
-    return suite
+        from TestNondimElasticDynamic import TestNondimElasticDynamic
+        suite.addTest(unittest.makeSuite(TestNondimElasticDynamic))
+
+        return suite
 
 
 # ----------------------------------------------------------------------
 if __name__ == '__main__':
-  app = TestApp()
-  app.run()
+    app = TestApp()
+    app.run()
 
 
-# End of file 
+# End of file

--- a/tests/pytests/utils/test_utils.py
+++ b/tests/pytests/utils/test_utils.py
@@ -18,31 +18,32 @@ from spatialdata.utils.UnitTestApp import UnitTestApp
 
 import unittest
 
+
 class TestApp(UnitTestApp):
-  """Test application.
-  """
-
-  def __init__(self):
-    """Constructor.
+    """Test application.
     """
-    UnitTestApp.__init__(self)
-    return
 
-  def _suite(self):
-    """Setup the test suite.
-    """
-    suite = unittest.TestSuite()
+    def __init__(self):
+        """Constructor.
+        """
+        UnitTestApp.__init__(self)
+        return
 
-    from TestSpatialdataVersion import TestSpatialdataVersion
-    suite.addTest(unittest.makeSuite(TestSpatialdataVersion))
+    def _suite(self):
+        """Setup the test suite.
+        """
+        suite = unittest.TestSuite()
 
-    return suite
+        from TestSpatialdataVersion import TestSpatialdataVersion
+        suite.addTest(unittest.makeSuite(TestSpatialdataVersion))
+
+        return suite
 
 
 # ----------------------------------------------------------------------
 if __name__ == '__main__':
-  app = TestApp()
-  app.run()
+    app = TestApp()
+    app.run()
 
 
-# End of file 
+# End of file


### PR DESCRIPTION
Migrate code to be compatible with Python 3 while maintaining compatibility with Python 2.

* Fix xrange/range.
* Fix import; use explicit relative import.
* Fix map; use list(map()).
* Fix raise exception.
* Fix print; use print().