### PR TITLE
Change `label` to `description` in SpatialDB and TimeHistory

### DIFF
--- a/docs/intro/preface.md
+++ b/docs/intro/preface.md
@@ -17,7 +17,7 @@ This is a tip, helpful hint, or suggestion.
 For features recently added to SpatialData, we show the version number when they
 were added.
 
-:::{info}
+:::{note}
 New in v2.8.0.
 :::
 

--- a/docs/user/nondimensionalization.md
+++ b/docs/user/nondimensionalization.md
@@ -43,7 +43,7 @@ The density scale will be very large in quasistatic problems, consistent with in
 ```
 
 :::{admonition} Pyre User Interface
-See [NondimensionalQuasistatic component](components/units/NondimensionalQuasistatic.md).
+See [NondimElasticQuasistatic component](components/units/NondimElasticQuasistatic.md).
 :::
 
 ## NondimensionalDynamic
@@ -61,5 +61,5 @@ The scales are specified in terms of the minimum shear wave speed, minimum densi
 ```
 
 :::{admonition} Pyre User Interface
-See [NondimensionalDynamic component](components/units/NondimensionalDynamic.md).
+See [NondimElasticDynamic component](components/units/NondimElasticDynamic.md).
 :::

--- a/docs/user/timedb/index.md
+++ b/docs/user/timedb/index.md
@@ -13,7 +13,7 @@ If a query request the amplitude at a time beyond the last point in the database
 The file format is described in {ref}`sec-file-formats-TimeHistoryDB`.
 
 :::{admonition} Pyre User Interface
-See [TimeHistoryDB component](../components/../spatialdb/TimeHistoryDB.md).
+See [TimeHistory component](../components/spatialdb/TimeHistory.md).
 :::
 
 ## Examples

--- a/libsrc/spatialdata/spatialdb/CompositeDB.cc
+++ b/libsrc/spatialdata/spatialdb/CompositeDB.cc
@@ -198,7 +198,7 @@ spatialdata::spatialdb::CompositeDB::setQueryValues(const char* const* names,
 
     if (0 == numVals) {
         std::ostringstream msg;
-        msg << "Number of values for query in spatial database " << getLabel()
+        msg << "Number of values for query in spatial database " << getDescription()
             << " must be positive.\n";
         throw std::invalid_argument(msg.str());
     } // if
@@ -319,14 +319,14 @@ spatialdata::spatialdb::CompositeDB::query(double* vals,
     const size_t querySize = qsizeA + qsizeB;
     if (0 == querySize) {
         std::ostringstream msg;
-        msg << "Values to be returned by spatial database " << getLabel()
+        msg << "Values to be returned by spatial database " << getDescription()
             << " have not been set. Please call setQueryValues() before query().\n";
         throw std::logic_error(msg.str());
     } // if
     else if (numVals != querySize) {
         std::ostringstream msg;
         msg << "Number of values to be returned by spatial database "
-            << getLabel()
+            << getDescription()
             << "(" << querySize << ") does not match size of array provided ("
             << numVals << ").\n";
         throw std::logic_error(msg.str());

--- a/libsrc/spatialdata/spatialdb/GravityField.cc
+++ b/libsrc/spatialdata/spatialdb/GravityField.cc
@@ -126,12 +126,12 @@ spatialdata::spatialdb::GravityField::setQueryValues(const char* const* names,
                                                      const size_t numVals) {
     if (0 == numVals) {
         std::ostringstream msg;
-        msg << "Number of values (" << numVals << ") for query of gravity field spatial database " << getLabel()
+        msg << "Number of values (" << numVals << ") for query of gravity field spatial database " << getDescription()
             << "\n must be positive.\n";
         throw std::invalid_argument(msg.str());
     } else if (numVals > 3) {
         std::ostringstream msg;
-        msg << "Number of values (" << numVals << ") for query of gravity field spatial database " << getLabel()
+        msg << "Number of values (" << numVals << ") for query of gravity field spatial database " << getDescription()
             << "\n must be 1, 2, or 3.\n";
         throw std::invalid_argument(msg.str());
     } // if/else
@@ -148,7 +148,7 @@ spatialdata::spatialdb::GravityField::setQueryValues(const char* const* names,
         } else {
             std::ostringstream msg;
             msg << "Could not find value '" << names[iVal] << "' in spatial database '"
-                << getLabel() << "'. Available values are: "
+                << getDescription() << "'. Available values are: "
                 << "'" << _GravityField::valueNames[0] << "', "
                 << "'" << _GravityField::valueNames[1] << "', "
                 << "'" << _GravityField::valueNames[2] << "'.";
@@ -170,13 +170,13 @@ spatialdata::spatialdb::GravityField::query(double* vals,
 
     if (0 == _querySize) {
         std::ostringstream msg;
-        msg << "Values to be returned by spatial database " << getLabel() << "\n"
+        msg << "Values to be returned by spatial database " << getDescription() << "\n"
             << "have not been set. Please call setQueryValues() before query().\n";
         throw std::logic_error(msg.str());
     } else if (numVals != _querySize) {
         std::ostringstream msg;
         msg << "Number of values to be returned by spatial database "
-            << getLabel() << "\n"
+            << getDescription() << "\n"
             << "(" << _querySize << ") does not match size of array provided ("
             << numVals << ").\n";
         throw std::logic_error(msg.str());

--- a/libsrc/spatialdata/spatialdb/SCECCVMH.cc
+++ b/libsrc/spatialdata/spatialdb/SCECCVMH.cc
@@ -204,7 +204,7 @@ spatialdata::spatialdb::SCECCVMH::setQueryValues(const char* const* names,
                                                  const size_t numVals) {
     if (0 == numVals) {
         std::ostringstream msg;
-        msg << "Number of values for query in spatial database " << getLabel()
+        msg << "Number of values for query in spatial database " << getDescription()
             << "\n must be positive.\n";
         throw std::invalid_argument(msg.str());
     } // if
@@ -230,7 +230,7 @@ spatialdata::spatialdb::SCECCVMH::setQueryValues(const char* const* names,
         } else {
             std::ostringstream msg;
             msg << "Could not find value '" << names[iVal] << "' in spatial database '"
-                << getLabel() << "'. Available values are:\n"
+                << getDescription() << "'. Available values are:\n"
                 << "vp, vs, density, topo-elev, basement-depth, moho-depth, vp-tag.";
             throw std::out_of_range(msg.str());
         } // else
@@ -248,13 +248,13 @@ spatialdata::spatialdb::SCECCVMH::query(double* vals,
                                         const spatialdata::geocoords::CoordSys* csQuery) {
     if (0 == _querySize) {
         std::ostringstream msg;
-        msg << "Values to be returned by spatial database " << getLabel() << "\n"
+        msg << "Values to be returned by spatial database " << getDescription() << "\n"
             << "have not been set. Please call setQueryValues() before query().\n";
         throw std::logic_error(msg.str());
     } else if (numVals != _querySize) {
         std::ostringstream msg;
         msg << "Number of values to be returned by spatial database "
-            << getLabel() << "\n"
+            << getDescription() << "\n"
             << "(" << _querySize << ") does not match size of array provided ("
             << numVals << ").\n";
         throw std::invalid_argument(msg.str());

--- a/libsrc/spatialdata/spatialdb/SimpleDB.cc
+++ b/libsrc/spatialdata/spatialdb/SimpleDB.cc
@@ -36,8 +36,7 @@ spatialdata::spatialdb::SimpleDB::SimpleDB(void) :
     _data(NULL),
     _iohandler(NULL),
     _query(NULL),
-    _cs(NULL)
-{}
+    _cs(NULL) {}
 
 
 // ----------------------------------------------------------------------
@@ -47,8 +46,7 @@ spatialdata::spatialdb::SimpleDB::SimpleDB(const char* label) :
     _data(NULL),
     _iohandler(NULL),
     _query(NULL),
-    _cs(NULL)
-{}
+    _cs(NULL) {}
 
 
 // ----------------------------------------------------------------------
@@ -146,7 +144,7 @@ spatialdata::spatialdb::SimpleDB::setQueryValues(const char* const* names,
                                                  const size_t numVals) {
     if (!_query) {
         std::ostringstream msg;
-        msg << "Spatial database " << getLabel() << " has not been opened.\n"
+        msg << "Spatial database " << getDescription() << " has not been opened.\n"
             << "Please call Open() before calling QueryVals().";
         throw std::logic_error(msg.str());
     } // if
@@ -165,13 +163,13 @@ spatialdata::spatialdb::SimpleDB::query(double* vals,
     try {
         if (!_query) {
             std::ostringstream msg;
-            msg << "Spatial database " << getLabel() << " has not been opened.\n"
+            msg << "Spatial database " << getDescription() << " has not been opened.\n"
                 << "Please call open() before calling query().";
             throw std::logic_error(msg.str());
         } // if
         else if (!_data) {
             std::ostringstream msg;
-            msg << "Spatial database " << getLabel() << " does not contain any data.\n"
+            msg << "Spatial database " << getDescription() << " does not contain any data.\n"
                 << "Database query aborted.";
             throw std::domain_error(msg.str());
         } // if

--- a/libsrc/spatialdata/spatialdb/SimpleDBQuery.cc
+++ b/libsrc/spatialdata/spatialdb/SimpleDBQuery.cc
@@ -81,7 +81,7 @@ spatialdata::spatialdb::SimpleDBQuery::setQueryValues(const char* const* names,
     assert(_db._data);
     if (0 == numVals) {
         std::ostringstream msg;
-        msg << "Number of values for query in spatial database " << _db.getLabel()
+        msg << "Number of values for query in spatial database " << _db.getDescription()
             << "\n must be positive.\n";
         throw std::invalid_argument(msg.str());
     } // if
@@ -101,7 +101,7 @@ spatialdata::spatialdb::SimpleDBQuery::setQueryValues(const char* const* names,
         if (iName >= numNames) {
             std::ostringstream msg;
             msg << "Could not find value '" << names[iVal] << "' in spatial database '"
-                << _db.getLabel() << "'. Available values are:";
+                << _db.getDescription() << "'. Available values are:";
             for (size_t iName = 0; iName < numNames; ++iName) {
                 msg << "\n  " << _db._data->getName(iName);
             }
@@ -125,14 +125,14 @@ spatialdata::spatialdb::SimpleDBQuery::query(double* vals,
 
     if (0 == _querySize) {
         std::ostringstream msg;
-        msg << "Values to be returned by spatial database " << _db.getLabel() << "\n"
+        msg << "Values to be returned by spatial database " << _db.getDescription() << "\n"
             << "have not been set. Please call setQueryValues() before query().\n";
         throw std::logic_error(msg.str());
     } // if
     else if (numVals != _querySize) {
         std::ostringstream msg;
         msg << "Number of values to be returned by spatial database "
-            << _db.getLabel() << "\n"
+            << _db.getDescription() << "\n"
             << "(" << _querySize << ") does not match size of array provided ("
             << numVals << ").\n";
         throw std::invalid_argument(msg.str());

--- a/libsrc/spatialdata/spatialdb/SimpleGridDB.cc
+++ b/libsrc/spatialdata/spatialdb/SimpleGridDB.cc
@@ -97,7 +97,7 @@ spatialdata::spatialdb::SimpleGridDB::open(void) {
         SpatialDB::_convertToSI(_data, _units, numLocs, _numValues);
     } catch (const std::exception& err) {
         std::ostringstream msg;
-        msg << "Error parsing units for spatial database '" << getLabel() << "':\n"
+        msg << "Error parsing units for spatial database '" << getDescription() << "':\n"
             << err.what();
         throw std::runtime_error(msg.str().c_str());
     } // try/catch
@@ -166,7 +166,7 @@ spatialdata::spatialdb::SimpleGridDB::setQueryValues(const char* const* names,
     if (0 == numVals) {
         std::ostringstream msg;
         msg
-            << "Number of values for query in spatial database " << getLabel()
+            << "Number of values for query in spatial database " << getDescription()
             << "\n must be positive.\n";
         throw std::invalid_argument(msg.str());
     } // if
@@ -186,7 +186,7 @@ spatialdata::spatialdb::SimpleGridDB::setQueryValues(const char* const* names,
         if (iName >= numNames) {
             std::ostringstream msg;
             msg << "Could not find value '" << names[iVal] << "' in spatial database '"
-                << getLabel() << "'. Available values are:";
+                << getDescription() << "'. Available values are:";
             for (size_t iName = 0; iName < numNames; ++iName) {
                 msg << "\n  " << _names[iName];
             } // for
@@ -210,13 +210,13 @@ spatialdata::spatialdb::SimpleGridDB::query(double* vals,
 
     if (0 == querySize) {
         std::ostringstream msg;
-        msg << "Values to be returned by spatial database " << getLabel() << "\n"
+        msg << "Values to be returned by spatial database " << getDescription() << "\n"
             << "have not been set. Please call setQueryValues() before query().\n";
         throw std::logic_error(msg.str());
     } else if (numVals != querySize) {
         std::ostringstream msg;
         msg << "Number of values to be returned by spatial database "
-            << getLabel() << "\n"
+            << getDescription() << "\n"
             << "(" << querySize << ") does not match size of array provided ("
             << numVals << ").\n";
         throw std::invalid_argument(msg.str());

--- a/libsrc/spatialdata/spatialdb/SpatialDB.cc
+++ b/libsrc/spatialdata/spatialdb/SpatialDB.cc
@@ -29,21 +29,18 @@
 // ----------------------------------------------------------------------
 /// Default constructor
 spatialdata::spatialdb::SpatialDB::SpatialDB(void) :
-    _label("")
-{}
+    _description("") {}
 
 
 // ----------------------------------------------------------------------
 /// Constructor with label
 spatialdata::spatialdb::SpatialDB::SpatialDB(const char* label) :
-    _label(label)
-{}
+    _description(label) {}
 
 
 // ----------------------------------------------------------------------
 /// Default destructor
-spatialdata::spatialdb::SpatialDB::~SpatialDB(void)
-{}
+spatialdata::spatialdb::SpatialDB::~SpatialDB(void) {}
 
 
 // ----------------------------------------------------------------------
@@ -114,7 +111,7 @@ spatialdata::spatialdb::SpatialDB::multiquery(float* vals,
                                               const float* coords,
                                               const size_t numLocsC,
                                               const size_t numDimsC,
-                                              const spatialdata::geocoords::CoordSys* csQuery) { // multiquery
+                                              const spatialdata::geocoords::CoordSys* csQuery) {
     assert(numLocsV == numLocsE);
     assert(numLocsC == numLocsE);
     assert( (!vals && 0 == numLocsV && 0 == numValsV) ||

--- a/libsrc/spatialdata/spatialdb/SpatialDB.hh
+++ b/libsrc/spatialdata/spatialdb/SpatialDB.hh
@@ -28,7 +28,7 @@
 #include <string> // USES std::string
 
 /// C++ manager for spatial database.
-class spatialdata::spatialdb::SpatialDB { // class SpatialDB
+class spatialdata::spatialdb::SpatialDB {
 public:
 
     // PUBLIC METHODS /////////////////////////////////////////////////////
@@ -45,17 +45,17 @@ public:
     /// Default destructor.
     virtual ~SpatialDB(void);
 
-    /** Set label of spatial database.
+    /** Set description of spatial database.
      *
-     * @param label Label for database
+     * @param description Description of database
      */
-    void setLabel(const char* label);
+    void setDescription(const char* description);
 
-    /** Get label of spatial database.
+    /** Get description of spatial database.
      *
-     * @returns Label for database
+     * @returns Description of database
      */
-    const char* getLabel(void) const;
+    const char* getDescription(void) const;
 
     /// Open the database and prepare for querying.
     virtual
@@ -216,7 +216,7 @@ private:
 
     // PRIVATE MEMBERS ////////////////////////////////////////////////////
 
-    std::string _label; ///< Label of spatial database.
+    std::string _description; ///< Description of spatial database.
 
 }; // class SpatialDB
 

--- a/libsrc/spatialdata/spatialdb/SpatialDB.icc
+++ b/libsrc/spatialdata/spatialdb/SpatialDB.icc
@@ -18,19 +18,19 @@
 #error "SpatialDB.icc must only be included from SpatialDB.hh"
 #endif
 
-// Set label of spatial database.
+// Set description of spatial database.
 inline
 void
-spatialdata::spatialdb::SpatialDB::setLabel(const char* label) {
-    _label = label;
+spatialdata::spatialdb::SpatialDB::setDescription(const char* description) {
+    _description = description;
 }
 
 
-// Get label of spatial database.
+// Get description of spatial database.
 inline
 const char*
-spatialdata::spatialdb::SpatialDB::getLabel(void) const {
-    return _label.c_str();
+spatialdata::spatialdb::SpatialDB::getDescription(void) const {
+    return _description.c_str();
 }
 
 

--- a/libsrc/spatialdata/spatialdb/TimeHistory.cc
+++ b/libsrc/spatialdata/spatialdb/TimeHistory.cc
@@ -25,25 +25,23 @@
 // ----------------------------------------------------------------------
 /// Default constructor
 spatialdata::spatialdb::TimeHistory::TimeHistory(void) :
-    _label(""),
+    _description(""),
     _filename(""),
     _time(0),
     _amplitude(0),
     _npts(0),
-    _ilower(0) { // constructor
-} // constructor
+    _ilower(0) {}
 
 
 // ----------------------------------------------------------------------
 /// Constructor with label
 spatialdata::spatialdb::TimeHistory::TimeHistory(const char* label) :
-    _label(label),
+    _description(label),
     _filename(""),
     _time(0),
     _amplitude(0),
     _npts(0),
-    _ilower(0)
-{}
+    _ilower(0) {}
 
 
 // ----------------------------------------------------------------------

--- a/libsrc/spatialdata/spatialdb/TimeHistory.hh
+++ b/libsrc/spatialdata/spatialdb/TimeHistory.hh
@@ -38,26 +38,26 @@ public:
     /// Default constructor.
     TimeHistory(void);
 
-    /** Constructor with label.
+    /** Constructor with description.
      *
-     * @param label Label for database
+     * @param description Description of database
      */
-    TimeHistory(const char* label);
+    TimeHistory(const char* description);
 
     /// Default destructor.
     ~TimeHistory(void);
 
-    /** Set label of time history.
+    /** Set description of time history.
      *
-     * @param label Label for time history.
+     * @param description Description for time history.
      */
-    void setLabel(const char* label);
+    void setDescription(const char* description);
 
-    /** Get label of time history.
+    /** Get description of time history.
      *
-     * @returns Label for time history.
+     * @returns Description for time history.
      */
-    const char* getLabel(void) const;
+    const char* getDescription(void) const;
 
     /** Set filename for time history.
      *
@@ -105,7 +105,7 @@ private:
 
     // PRIVATE MEMBERS ////////////////////////////////////////////////////
 
-    std::string _label; ///< Label of time history.
+    std::string _description; ///< Description of time history.
     std::string _filename; ///< Name of time history file
     double* _time; ///< Time stamps for points in time history.
     double* _amplitude; ///< Amplitude at points in time history.

--- a/libsrc/spatialdata/spatialdb/TimeHistory.icc
+++ b/libsrc/spatialdata/spatialdb/TimeHistory.icc
@@ -18,19 +18,19 @@
 #error "TimeHistory.icc must only be included from TimeHistory.hh"
 #endif
 
-// Set label of time history.
+// Set description of time history.
 inline
 void
-spatialdata::spatialdb::TimeHistory::setLabel(const char* label) {
-    _label = label;
+spatialdata::spatialdb::TimeHistory::setDescription(const char* description) {
+    _description = description;
 }
 
 
-// Get label of time history.
+// Get description of time history.
 inline
 const char*
-spatialdata::spatialdb::TimeHistory::getLabel(void) const {
-    return _label.c_str();
+spatialdata::spatialdb::TimeHistory::getDescription(void) const {
+    return _description.c_str();
 }
 
 

--- a/libsrc/spatialdata/spatialdb/UniformDB.cc
+++ b/libsrc/spatialdata/spatialdb/UniformDB.cc
@@ -37,8 +37,7 @@ spatialdata::spatialdb::UniformDB::UniformDB(void) :
     _values(NULL),
     _queryValues(NULL),
     _numValues(0),
-    _querySize(0)
-{}
+    _querySize(0) {}
 
 
 // ----------------------------------------------------------------------
@@ -49,8 +48,7 @@ spatialdata::spatialdb::UniformDB::UniformDB(const char* label) :
     _values(NULL),
     _queryValues(NULL),
     _numValues(0),
-    _querySize(0)
-{}
+    _querySize(0) {}
 
 
 // ----------------------------------------------------------------------
@@ -138,7 +136,7 @@ spatialdata::spatialdb::UniformDB::setQueryValues(const char* const* names,
                                                   const size_t numVals) {
     if (0 == numVals) {
         std::ostringstream msg;
-        msg << "Number of values for query in spatial database " << getLabel()
+        msg << "Number of values for query in spatial database " << getDescription()
             << "\n must be positive.\n";
         throw std::invalid_argument(msg.str());
     } // if
@@ -157,7 +155,7 @@ spatialdata::spatialdb::UniformDB::setQueryValues(const char* const* names,
         if (iName >= _numValues) {
             std::ostringstream msg;
             msg << "Could not find value '" << names[iVal] << "' in spatial database '"
-                << getLabel() << "'. Available values are:";
+                << getDescription() << "'. Available values are:";
             for (size_t iName = 0; iName < _numValues; ++iName) {
                 msg << "\n  " << _names[iName];
                 msg << "\n";
@@ -179,14 +177,14 @@ spatialdata::spatialdb::UniformDB::query(double* vals,
                                          const spatialdata::geocoords::CoordSys* pCSQuery) {
     if (0 == _querySize) {
         std::ostringstream msg;
-        msg << "Values to be returned by spatial database " << getLabel() << "\n"
+        msg << "Values to be returned by spatial database " << getDescription() << "\n"
             << "have not been set. Please call setQueryValues() before query().\n";
         throw std::logic_error(msg.str());
     } // if
     else if (numVals != _querySize) {
         std::ostringstream msg;
         msg << "Number of values to be returned by spatial database "
-            << getLabel() << "\n"
+            << getDescription() << "\n"
             << "(" << _querySize << ") does not match size of array provided ("
             << numVals << ").\n";
         throw std::invalid_argument(msg.str());

--- a/libsrc/spatialdata/spatialdb/UserFunctionDB.cc
+++ b/libsrc/spatialdata/spatialdb/UserFunctionDB.cc
@@ -228,7 +228,7 @@ spatialdata::spatialdb::UserFunctionDB::setQueryValues(const char* const* names,
                                                        const size_t numVals) {
     if (0 == numVals) {
         std::ostringstream msg;
-        msg << "Number of values for query in spatial database " << getLabel()
+        msg << "Number of values for query in spatial database " << getDescription()
             << "\n must be positive.\n";
         throw std::invalid_argument(msg.str());
     } // if
@@ -241,7 +241,7 @@ spatialdata::spatialdb::UserFunctionDB::setQueryValues(const char* const* names,
         if (_functions.end() == iter) {
             std::ostringstream msg;
             msg << "Could not find value '" << names[iVal] << "' in spatial database '"
-                << getLabel() << "'. Available values are:";
+                << getDescription() << "'. Available values are:";
             for (function_map::iterator viter = _functions.begin(); viter != _functions.end(); ++viter) {
                 msg << "\n  " << viter->first;
             } // for
@@ -268,13 +268,13 @@ spatialdata::spatialdb::UserFunctionDB::query(double* vals,
 
     if (0 == querySize) {
         std::ostringstream msg;
-        msg << "Values to be returned by spatial database " << getLabel()
+        msg << "Values to be returned by spatial database " << getDescription()
             << " have not been set. Please call setQueryValues() before query().\n";
         throw std::logic_error(msg.str());
     } else if (numVals != querySize) {
         std::ostringstream msg;
         msg << "Number of values to be returned by spatial database "
-            << getLabel() << " (" << querySize << ") does not match size of array provided ("
+            << getDescription() << " (" << querySize << ") does not match size of array provided ("
             << numVals << ").\n";
         throw std::invalid_argument(msg.str());
     } else if (numDims != _cs->getSpaceDim()) {
@@ -318,13 +318,13 @@ spatialdata::spatialdb::UserFunctionDB::_checkAdd(const char* name,
                                                   const char* units) const {
     if (!name) {
         std::ostringstream msg;
-        msg << "NULL name passed to addValue() for spatial database " << getLabel() << ".";
+        msg << "NULL name passed to addValue() for spatial database " << getDescription() << ".";
         throw std::logic_error(msg.str());
     } // if
 
     if (!units) {
         std::ostringstream msg;
-        msg << "NULL units passed to addValue() for spatial database " << getLabel() << ".";
+        msg << "NULL units passed to addValue() for spatial database " << getDescription() << ".";
         throw std::logic_error(msg.str());
     } // if
 
@@ -332,14 +332,14 @@ spatialdata::spatialdb::UserFunctionDB::_checkAdd(const char* name,
     const function_map::const_iterator& iter = _functions.find(name);
     if (iter != _functions.end()) {
         std::ostringstream msg;
-        msg << "Cannot add user function for value " << name << " to spatial database " << getLabel()
+        msg << "Cannot add user function for value " << name << " to spatial database " << getDescription()
             << ". User function for value already exists.";
         throw std::logic_error(msg.str());
     } // if
 
     if (!fn) {
         std::ostringstream msg;
-        msg << "Cannot add NULL user function for value " << name << " to spatial database " << getLabel() << ".";
+        msg << "Cannot add NULL user function for value " << name << " to spatial database " << getDescription() << ".";
         throw std::invalid_argument(msg.str());
     } // if
 } // _checkAdd
@@ -353,7 +353,7 @@ spatialdata::spatialdb::UserFunctionDB::_checkCompatibility(void) const {
 
     if (!_cs) {
         std::ostringstream msg;
-        msg << "Coordinate system has not been set for spatial database " << getLabel() << ".";
+        msg << "Coordinate system has not been set for spatial database " << getDescription() << ".";
         throw std::logic_error(msg.str());
     } // if
 
@@ -368,7 +368,7 @@ spatialdata::spatialdb::UserFunctionDB::_checkCompatibility(void) const {
         if (flag) {
             std::ostringstream msg;
             msg << "Error encountered in verifying compatibility for user function " << typeid(iter->second.fn).name()
-                << " for value '" << iter->first << "' in spatial database " << getLabel() << ".";
+                << " for value '" << iter->first << "' in spatial database " << getDescription() << ".";
             throw std::runtime_error(msg.str());
         } // if
     } // for

--- a/modulesrc/spatialdb/SpatialDBObj.i
+++ b/modulesrc/spatialdb/SpatialDBObj.i
@@ -20,148 +20,149 @@
  */
 
 namespace spatialdata {
-  namespace geocoords {
-    class CoordSys; // forward declaration
-  } // geocoords
+    namespace geocoords {
+        class CoordSys; // forward declaration
+    } // geocoords
 
-  namespace spatialdb {
+    namespace spatialdb {
+        class SpatialDB
+        { // class SpatialDB
+public:
 
-    class SpatialDB
-    { // class SpatialDB
+            // PUBLIC METHODS /////////////////////////////////////////////////
 
-    public :
-      // PUBLIC METHODS /////////////////////////////////////////////////
-  
-      /// Default constructor.
-      SpatialDB(void);
-  
-      /** Constructor with label.
-       *
-       * @param label Label for database
-       */
-      SpatialDB(const char* label);
-  
-      /// Default destructor.
-      virtual
-      ~SpatialDB(void);
-      
-      /** Set label of spatial database.
-       *
-       * @param label Label for database
-       */
-      void setLabel(const char* label);
-      
-      /** Get label of spatial database.
-       *
-       * @returns Label for database
-       */
-      const char* getLabel(void) const;
-      
-      /// Open the database and prepare for querying.
-      virtual
-      void open(void) = 0;
-      
-      /// Close the database.
-      virtual
-      void close(void) = 0;
-      
-      /** Set values to be returned by queries.
-       *
-       * @pre Must call open() before setQueryValues()
-       *
-       * @param names Names of values to be returned in queries
-       * @param numVals Number of values to be returned in queries
-       */
-      %apply(const char* const* string_list, const int list_len){
-	(const char* const* names, const size_t numVals)
-	  };
-      virtual
-      void setQueryValues(const char* const* names,
-		     const size_t numVals) = 0;
-      %clear(const char* const* names, const size_t numVals);
+            /// Default constructor.
+            SpatialDB(void);
 
-      /** Query the database.
-       *
-       * @note vals should be preallocated to accommodate numVals values.
-       *
-       * @pre Must call open() before query().
-       *
-       * @param vals Array for computed values (output from query), must be
-       *   allocated BEFORE calling query().
-       * @param numVals Number of values expected (size of pVals array)
-       * @param coords Coordinates of point for query [numDims].
-       * @param numDims Number of dimensions for coordinates.
-       * @param csQuery Coordinate system of coordinates.
-       *
-       * @returns 0 on success, 1 on failure (i.e., could not interpolate)
-       */
-      %apply(double* INPLACE_ARRAY1, int DIM1) {
-	(double* vals, const size_t numVals)
-	  };
-      %apply(double* IN_ARRAY1, int DIM1) {
-	(const double* coords, const size_t numDims)
-	  };
-      virtual
-      int query(double* vals,
-		const size_t numVals,
-		const double* coords,
-		const size_t numDims,
-		const spatialdata::geocoords::CoordSys* csQuery) = 0;
-      %clear(double* vals, const size_t numVals);
-      %clear(const double* coords, const size_t numDims);
-      
-      /** Perform multiple queries of the database.
-       *
-       * @note vals should be preallocated to accommodate numVals values
-       * at numLocs locations.
-       *
-       * @note err should be preallocated to accommodate numLocs values.
-       *
-       * @pre Must call open() before query().
-       *
-       * @param vals Array for computed values (output from query), must be
-       *   allocated BEFORE calling query() [numLocs*numVals].
-       * @param numLocsV Number of locations.
-       * @param numValsV Number of values expected.
-       * @param err Array for error flag values (output from query), must be
-       *   allocated BEFORE calling query() [numLocs].
-       * @param numLocsE Number of locations.
-       * @param coords Coordinates of point for query [numLocs*numDims].
-       * @param numLocsC Number of locations.
-       * @param numDimsC Number of dimensions for coordinates.
-       * @param csQuery Coordinate system of coordinates.
-       */
-      %apply(double* INPLACE_ARRAY2, int DIM1, int DIM2) {
-	(double* vals,
-	 const size_t numLocsV,
-	 const size_t numValsV)
-	  };
-      %apply(int* INPLACE_ARRAY1, int DIM1) {
-	(int* err,
-	 const size_t numLocsE)
-	  };
-      %apply(double* IN_ARRAY2, int DIM1, int DIM2) {
-	(const double* coords,
-	 const size_t numLocsC,
-	 const size_t numDimsC)
-	  };
-      void multiquery(double* vals,
-		      const size_t numLocsV,
-		      const size_t numValsV,
-		      int* err,
-		      const size_t numLocsE,
-		      const double* coords,
-		      const size_t numLocsC,
-		      const size_t numDimsC,
-		      const spatialdata::geocoords::CoordSys* csQuery);
-      %clear(double* vals, const size_t numLocsV, const size_t numValsV);
-      %clear(int* err, const size_t numLocsE);
-      %clear(const double* coords, const size_t numLocsC, const size_t numDimsC);
-      
-    }; // class SpatialDB
-    
-  } // spatialdb
+            /** Constructor with description.
+             *
+             * @param description Description for database
+             */
+            SpatialDB(const char* description);
+
+            /// Default destructor.
+            virtual
+            ~SpatialDB(void);
+
+            /** Set description of spatial database.
+             *
+             * @param description Description for database
+             */
+            void setDescription(const char* description);
+
+            /** Get description of spatial database.
+             *
+             * @returns Description for database
+             */
+            const char* getDescription(void) const;
+
+            /// Open the database and prepare for querying.
+            virtual
+            void open(void) = 0;
+
+            /// Close the database.
+            virtual
+            void close(void) = 0;
+
+            /** Set values to be returned by queries.
+             *
+             * @pre Must call open() before setQueryValues()
+             *
+             * @param names Names of values to be returned in queries
+             * @param numVals Number of values to be returned in queries
+             */
+            %apply(const char* const* string_list, const int list_len) {
+                (const char* const* names, const size_t numVals)
+            };
+            virtual
+            void setQueryValues(const char* const* names,
+                                const size_t numVals) = 0;
+
+            %clear(const char* const* names, const size_t numVals);
+
+            /** Query the database.
+             *
+             * @note vals should be preallocated to accommodate numVals values.
+             *
+             * @pre Must call open() before query().
+             *
+             * @param vals Array for computed values (output from query), must be
+             *   allocated BEFORE calling query().
+             * @param numVals Number of values expected (size of pVals array)
+             * @param coords Coordinates of point for query [numDims].
+             * @param numDims Number of dimensions for coordinates.
+             * @param csQuery Coordinate system of coordinates.
+             *
+             * @returns 0 on success, 1 on failure (i.e., could not interpolate)
+             */
+            %apply(double* INPLACE_ARRAY1, int DIM1) {
+                (double* vals, const size_t numVals)
+            };
+            %apply(double* IN_ARRAY1, int DIM1) {
+                (const double* coords, const size_t numDims)
+            };
+            virtual
+            int query(double* vals,
+                      const size_t numVals,
+                      const double* coords,
+                      const size_t numDims,
+                      const spatialdata::geocoords::CoordSys* csQuery) = 0;
+
+            %clear(double* vals, const size_t numVals);
+            %clear(const double* coords, const size_t numDims);
+
+            /** Perform multiple queries of the database.
+             *
+             * @note vals should be preallocated to accommodate numVals values
+             * at numLocs locations.
+             *
+             * @note err should be preallocated to accommodate numLocs values.
+             *
+             * @pre Must call open() before query().
+             *
+             * @param vals Array for computed values (output from query), must be
+             *   allocated BEFORE calling query() [numLocs*numVals].
+             * @param numLocsV Number of locations.
+             * @param numValsV Number of values expected.
+             * @param err Array for error flag values (output from query), must be
+             *   allocated BEFORE calling query() [numLocs].
+             * @param numLocsE Number of locations.
+             * @param coords Coordinates of point for query [numLocs*numDims].
+             * @param numLocsC Number of locations.
+             * @param numDimsC Number of dimensions for coordinates.
+             * @param csQuery Coordinate system of coordinates.
+             */
+            %apply(double* INPLACE_ARRAY2, int DIM1, int DIM2) {
+                (double* vals,
+                 const size_t numLocsV,
+                 const size_t numValsV)
+            };
+            %apply(int* INPLACE_ARRAY1, int DIM1) {
+                (int* err,
+                 const size_t numLocsE)
+            };
+            %apply(double* IN_ARRAY2, int DIM1, int DIM2) {
+                (const double* coords,
+                 const size_t numLocsC,
+                 const size_t numDimsC)
+            };
+            void multiquery(double* vals,
+                            const size_t numLocsV,
+                            const size_t numValsV,
+                            int* err,
+                            const size_t numLocsE,
+                            const double* coords,
+                            const size_t numLocsC,
+                            const size_t numDimsC,
+                            const spatialdata::geocoords::CoordSys* csQuery);
+
+            %clear(double* vals, const size_t numLocsV, const size_t numValsV);
+            %clear(int* err, const size_t numLocsE);
+            %clear(const double* coords, const size_t numLocsC, const size_t numDimsC);
+
+        }; // class SpatialDB
+
+    } // spatialdb
 } // spatialdata
 
-
-// End of file 
+// End of file

--- a/modulesrc/spatialdb/TimeHistory.i
+++ b/modulesrc/spatialdb/TimeHistory.i
@@ -20,74 +20,73 @@
  */
 
 namespace spatialdata {
-  namespace spatialdb {
+    namespace spatialdb {
+        class TimeHistory
+        { // class TimeHistory
+public:
 
-    class TimeHistory
-    { // class TimeHistory
+            // PUBLIC METHODS /////////////////////////////////////////////////
 
-    public :
-      // PUBLIC METHODS /////////////////////////////////////////////////
-  
-      /// Default constructor.
-      TimeHistory(void);
-  
-      /** Constructor with label.
-       *
-       * @param label Label for database
-       */
-      TimeHistory(const char* label);
-      
-      /// Default destructor.
-      ~TimeHistory(void);
+            /// Default constructor.
+            TimeHistory(void);
 
-      /** Set label of time history.
-       *
-       * @param label Label for time history.
-       */
-      void setLabel(const char* label);
-  
-      /** Get label of time history.
-       *
-       * @returns Label for time history.
-       */
-      const char* getLabel(void) const;
-      
-      /** Set filename for time history.
-       *
-       * @param name Name of file.
-       */
-      void setFilename(const char* name);
-      
-      /** Set filename for time history.
-       *
-       * @return Name of file.
-       */
-      const char* getFilename(void);
-      
-      /// Open the time history and prepare for querying.
-      void open(void);
-      
-      /// Close the time history.
-      void close(void);
-      
-      /** Query the database.
-       *
-       * @pre Must call open() before query()
-       *
-       * @param value Value in time history.
-       * @param t Time for query.
-       *
-       * @returns 0 on success, 1 on failure (i.e., could not interpolate)
-       */
-      %apply double* OUTPUT { double* value };
-      int query(double* value,
-		const double t);
-      %clear (double* value);
-        
-    }; // class TimeHistory
+            /** Constructor with description.
+             *
+             * @param description Description for database
+             */
+            TimeHistory(const char* description);
 
-  } // spatialdb
+            /// Default destructor.
+            ~TimeHistory(void);
+
+            /** Set description of time history.
+             *
+             * @param description Description for time history.
+             */
+            void setDescription(const char* description);
+
+            /** Get description of time history.
+             *
+             * @returns Description for time history.
+             */
+            const char* getDescription(void) const;
+
+            /** Set filename for time history.
+             *
+             * @param name Name of file.
+             */
+            void setFilename(const char* name);
+
+            /** Set filename for time history.
+             *
+             * @return Name of file.
+             */
+            const char* getFilename(void);
+
+            /// Open the time history and prepare for querying.
+            void open(void);
+
+            /// Close the time history.
+            void close(void);
+
+            /** Query the database.
+             *
+             * @pre Must call open() before query()
+             *
+             * @param value Value in time history.
+             * @param t Time for query.
+             *
+             * @returns 0 on success, 1 on failure (i.e., could not interpolate)
+             */
+            %apply double* OUTPUT { double* value };
+            int query(double* value,
+                      const double t);
+
+            %clear(double* value);
+
+        }; // class TimeHistory
+
+    } // spatialdb
 } // spatialdata
 
-
-// End of file 
+// End of file

--- a/spatialdata/spatialdb/SCECCVMH.py
+++ b/spatialdata/spatialdb/SCECCVMH.py
@@ -70,7 +70,7 @@ class SCECCVMH(SpatialDBObj, ModuleSCECCVMH):
         Set members based on inventory.
         """
         SpatialDBObj._configure(self)
-        ModuleSCECCVMH.setLabel(self, "SCEC CVM-H")
+        ModuleSCECCVMH.setDescription(self, "SCEC CVM-H")
         ModuleSCECCVMH.setDataDir(self, self.dataDir)
         ModuleSCECCVMH.setMinVs(self, self.minVs.value)
         ModuleSCECCVMH.setSquashFlag(self, self.squash, self.squashLimit.value)

--- a/spatialdata/spatialdb/SimpleGridAscii.py
+++ b/spatialdata/spatialdb/SimpleGridAscii.py
@@ -94,7 +94,7 @@ class SimpleGridAscii(Component, ModuleSimpleGridAscii):
         from .SimpleGridDB import SimpleGridDB
         db = SimpleGridDB()
         db._configure()
-        db.setLabel("Temporary SimpleGridDB for writing")
+        db.setDescription("Temporary SimpleGridDB for writing")
         db.setFilename(self.filename)
         db.setCoordSys(data['coordsys'])
         db.allocate(numX, numY, numZ, numValues, spaceDim, data['data_dim'])

--- a/spatialdata/spatialdb/SpatialDBObj.py
+++ b/spatialdata/spatialdb/SpatialDBObj.py
@@ -16,12 +16,12 @@ from pythia.pyre.components.Component import Component
 from .spatialdb import SpatialDB as ModuleSpatialDB
 
 
-def validateLabel(value):
+def validateDescription(value):
     """
-    Validate label for spatial database.
+    Validate description for spatial database.
     """
     if 0 == len(value):
-        raise ValueError("Descriptive label for spatial database not specified.")
+        raise ValueError("Descriptive description for spatial database not specified.")
     return value
 
 
@@ -32,8 +32,8 @@ class SpatialDBObj(Component, ModuleSpatialDB):
 
     import pythia.pyre.inventory
 
-    label = pythia.pyre.inventory.str("label", default="", validator=validateLabel)
-    label.meta['tip'] = "Descriptive label for database."
+    description = pythia.pyre.inventory.str("description", default="", validator=validateDescription)
+    description.meta['tip'] = "Descriptive description for database."
 
     # PUBLIC METHODS /////////////////////////////////////////////////////
 
@@ -52,7 +52,7 @@ class SpatialDBObj(Component, ModuleSpatialDB):
         """
         Component._configure(self)
         self._createModuleObj()
-        ModuleSpatialDB.setLabel(self, self.label)
+        ModuleSpatialDB.setDescription(self, self.description)
         return
 
     def _createModuleObj(self):

--- a/spatialdata/spatialdb/TimeHistory.py
+++ b/spatialdata/spatialdb/TimeHistory.py
@@ -36,15 +36,15 @@ class TimeHistory(Component, ModuleTimeHistory):
     DOC_CONFIG = {
         "cfg": """
             [timehistory]
-            label = Time history for Dirichlet boundary condition
+            description = Time history for Dirichlet boundary condition
             filename = displacement.timedb
             """,
     }
 
     import pythia.pyre.inventory
 
-    label = pythia.pyre.inventory.str("label", default="temporal database")
-    label.meta['tip'] = "Label for time history."
+    description = pythia.pyre.inventory.str("description", default="temporal database")
+    description.meta['tip'] = "Description for time history."
 
     filename = pythia.pyre.inventory.str("filename", default="timehistory.timedb", validator=validateFilename)
     filename.meta['tip'] = "Name of file for time history."
@@ -65,7 +65,7 @@ class TimeHistory(Component, ModuleTimeHistory):
         """
         Component._configure(self)
         self._createModuleObj()
-        ModuleTimeHistory.setLabel(self, self.label)
+        ModuleTimeHistory.setDescription(self, self.description)
         ModuleTimeHistory.setFilename(self, self.filename)
 
     def _createModuleObj(self):
@@ -77,9 +77,9 @@ class TimeHistory(Component, ModuleTimeHistory):
 
 # FACTORIES ////////////////////////////////////////////////////////////
 
-def createWriter(filename, label="Time history writer"):
+def createWriter(filename, description="Time history writer"):
     writer = TimeHistory()
-    writer.setLabel(label)
+    writer.setDescription(description)
     writer.setFilename(filename)
     return writer
 

--- a/tests/libtests/spatialdb/TestCompositeDB.cc
+++ b/tests/libtests/spatialdb/TestCompositeDB.cc
@@ -119,7 +119,7 @@ spatialdata::spatialdb::TestCompositeDB::testConstructors(void) {
 
     const std::string label("database A");
     CompositeDB db2(label.c_str());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in db label.", label, std::string(db2.getLabel()));
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in db label.", label, std::string(db2.getDescription()));
 } // testConstructors
 
 
@@ -130,8 +130,8 @@ spatialdata::spatialdb::TestCompositeDB::testAccessors(void) {
     const std::string label("database 2");
 
     CompositeDB db;
-    db.setLabel(label.c_str());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in label.", label, std::string(db.getLabel()));
+    db.setDescription(label.c_str());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in label.", label, std::string(db.getDescription()));
 
     // Set database A
     const size_t numNamesA = 2;

--- a/tests/libtests/spatialdb/TestGravityField.cc
+++ b/tests/libtests/spatialdb/TestGravityField.cc
@@ -63,8 +63,8 @@ spatialdata::spatialdb::TestGravityField::testAccessors(void) {
     const double tolerance = 1.0e-06;
 
     const std::string label("database 2");
-    db.setLabel(label.c_str());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in database label.", label, std::string(db.getLabel()));
+    db.setDescription(label.c_str());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in database label.", label, std::string(db.getDescription()));
 
     const double gravityDirDefault[3] = { 0.0, 0.0, -1.0 };
     for (size_t i = 0; i < 3; ++i) {

--- a/tests/libtests/spatialdb/TestSCECCVMH.cc
+++ b/tests/libtests/spatialdb/TestSCECCVMH.cc
@@ -91,15 +91,15 @@ spatialdata::spatialdb::TestSCECCVMH::testConstructor(void) {
 
 
 // ----------------------------------------------------------------------
-// Test Label().
+// Test accessors.
 void
 spatialdata::spatialdb::TestSCECCVMH::testAccessors(void) {
     SCECCVMH db;
 
-    // Label
+    // Description
     const std::string label("database 2");
-    db.setLabel(label.c_str());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in database label.", label, std::string(db.getLabel()));
+    db.setDescription(label.c_str());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in database label.", label, std::string(db.getDescription()));
 
     // Data directory
     const std::string dataDir("/path/to/data/dir");

--- a/tests/libtests/spatialdb/TestSimpleDB.cc
+++ b/tests/libtests/spatialdb/TestSimpleDB.cc
@@ -51,7 +51,7 @@ spatialdata::spatialdb::TestSimpleDB::testConstructors(void) {
 
     const std::string label("database A");
     SimpleDB db2(label.c_str());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in database label.", label, std::string(db2.getLabel()));
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in database label.", label, std::string(db2.getDescription()));
 } // testConstructors
 
 
@@ -62,8 +62,8 @@ spatialdata::spatialdb::TestSimpleDB::testAccessors(void) {
     CPPUNIT_ASSERT(_db);
 
     const std::string label("database 2");
-    _db->setLabel(label.c_str());
-    CPPUNIT_ASSERT_EQUAL(label, std::string(_db->getLabel()));
+    _db->setDescription(label.c_str());
+    CPPUNIT_ASSERT_EQUAL(label, std::string(_db->getDescription()));
 
     spatialdata::spatialdb::SimpleIOAscii io;
     const std::string filename("db.spatialdb");

--- a/tests/libtests/spatialdb/TestSimpleGridAscii.cc
+++ b/tests/libtests/spatialdb/TestSimpleGridAscii.cc
@@ -213,7 +213,7 @@ spatialdata::spatialdb::TestSimpleGridAscii::testIOCSGeo(void) {
     SimpleGridAscii::write(dbOut);
 
     SimpleGridDB dbIn;
-    dbIn.setLabel("GridDB geo");
+    dbIn.setDescription("GridDB geo");
     dbIn.setFilename(filename);
     dbIn.open();
 
@@ -328,7 +328,7 @@ spatialdata::spatialdb::TestSimpleGridAscii::testReadComments(void) {
 
     const char* filename = "data/grid_comments.spatialdb";
     SimpleGridDB dbIn;
-    dbIn.setLabel("GridDB geo");
+    dbIn.setDescription("GridDB geo");
     dbIn.setFilename(filename);
     dbIn.open();
 

--- a/tests/libtests/spatialdb/TestSimpleGridDB.cc
+++ b/tests/libtests/spatialdb/TestSimpleGridDB.cc
@@ -55,8 +55,8 @@ spatialdata::spatialdb::TestSimpleGridDB::testAccessors(void) {
     const std::string label("database 2");
     const std::string filename("mydb.spatialdb");
 
-    db.setLabel(label.c_str());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in label.", label, std::string(db.getLabel()));
+    db.setDescription(label.c_str());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in label.", label, std::string(db.getDescription()));
 
     db.setFilename(filename.c_str());
     CPPUNIT_ASSERT_EQUAL_MESSAGE("Mismatch in filename.", filename, db._filename);
@@ -275,7 +275,7 @@ spatialdata::spatialdb::TestSimpleGridDB::_setupDB(SimpleGridDB* const db) {
     delete[] db->_names;db->_names = NULL;
     delete[] db->_units;db->_units = NULL;
 
-    db->setLabel("Test database");
+    db->setDescription("Test database");
     db->_numValues = _data->numValues;
     db->_spaceDim = _data->spaceDim;
     db->_dataDim = _data->dataDim;

--- a/tests/libtests/spatialdb/TestTimeHistory.cc
+++ b/tests/libtests/spatialdb/TestTimeHistory.cc
@@ -63,8 +63,8 @@ spatialdata::spatialdb::TestTimeHistory::testAccessors(void) {
     const std::string filename("file.th");
 
     TimeHistory th;
-    th.setLabel(label.c_str());
-    CPPUNIT_ASSERT_EQUAL(label, std::string(th.getLabel()));
+    th.setDescription(label.c_str());
+    CPPUNIT_ASSERT_EQUAL(label, std::string(th.getDescription()));
 
     th.setFilename(filename.c_str());
     CPPUNIT_ASSERT_EQUAL(filename, std::string(th.getFilename()));

--- a/tests/libtests/spatialdb/TestUniformDB.cc
+++ b/tests/libtests/spatialdb/TestUniformDB.cc
@@ -74,7 +74,7 @@ spatialdata::spatialdb::TestUniformDB::testConstructors(void) {
 
     const std::string label("database A");
     UniformDB dbL(label.c_str());
-    CPPUNIT_ASSERT_EQUAL(label, std::string(dbL.getLabel()));
+    CPPUNIT_ASSERT_EQUAL(label, std::string(dbL.getDescription()));
 } // testConstructors
 
 
@@ -85,8 +85,8 @@ spatialdata::spatialdb::TestUniformDB::testAccessors(void) {
     const std::string label("database 2");
 
     UniformDB db;
-    db.setLabel(label.c_str());
-    CPPUNIT_ASSERT_EQUAL(label, std::string(db.getLabel()));
+    db.setDescription(label.c_str());
+    CPPUNIT_ASSERT_EQUAL(label, std::string(db.getDescription()));
 } // testAccessors
 
 

--- a/tests/libtests/spatialdb/TestUserFunctionDB.cc
+++ b/tests/libtests/spatialdb/TestUserFunctionDB.cc
@@ -52,11 +52,11 @@ spatialdata::spatialdb::TestUserFunctionDB::testConstructor(void) {
 // ----------------------------------------------------------------------
 // Test label()
 void
-spatialdata::spatialdb::TestUserFunctionDB::testLabel(void) {
+spatialdata::spatialdb::TestUserFunctionDB::testDescription(void) {
     const std::string& label = "database 2";
-    _db->setLabel(label.c_str());
-    CPPUNIT_ASSERT_EQUAL(label, std::string(_db->getLabel()));
-} // testLabel
+    _db->setDescription(label.c_str());
+    CPPUNIT_ASSERT_EQUAL(label, std::string(_db->getDescription()));
+} // testDescription
 
 
 // ----------------------------------------------------------------------
@@ -259,8 +259,7 @@ spatialdata::spatialdb::TestUserFunctionDB_Data::TestUserFunctionDB_Data(void) :
     cs(NULL),
     queryXYZ(NULL),
     queryValues(NULL),
-    numQueryPoints(0)
-{}
+    numQueryPoints(0) {}
 
 
 // ----------------------------------------------------------------------

--- a/tests/libtests/spatialdb/TestUserFunctionDB.hh
+++ b/tests/libtests/spatialdb/TestUserFunctionDB.hh
@@ -43,7 +43,7 @@ class spatialdata::spatialdb::TestUserFunctionDB : public CppUnit::TestFixture {
     CPPUNIT_TEST_SUITE(TestUserFunctionDB);
 
     CPPUNIT_TEST(testConstructor);
-    CPPUNIT_TEST(testLabel);
+    CPPUNIT_TEST(testDescription);
     CPPUNIT_TEST(testAddValue);
     CPPUNIT_TEST(testCoordsys);
     CPPUNIT_TEST(testOpenClose);
@@ -66,7 +66,7 @@ public:
     void testConstructor(void);
 
     /// Test label()
-    void testLabel(void);
+    void testDescription(void);
 
     /// Test addValue()
     void testAddValue(void);

--- a/tests/pytests/spatialdb/gensimpledb.cfg
+++ b/tests/pytests/spatialdb/gensimpledb.cfg
@@ -26,7 +26,7 @@ shapers = [bg, add, multiply]
 default = 0.0
 operand = add
 db_value = One
-db.label = DB1: background
+db.description = DB1: background
 db.query_type = linear
 db.iohandler.filename = data/gen1Din2D_one_bg.spatialdb
 
@@ -34,7 +34,7 @@ db.iohandler.filename = data/gen1Din2D_one_bg.spatialdb
 default = 1.0
 operand = add
 db_value = One
-db.label = DB1: add
+db.description = DB1: add
 db.query_type = linear
 db.iohandler.filename = data/gen1Din2D_one_add.spatialdb
 
@@ -42,7 +42,7 @@ db.iohandler.filename = data/gen1Din2D_one_add.spatialdb
 default = 0.0
 operand = multiply
 db_value = One
-db.label = DB1: multiply
+db.description = DB1: multiply
 db.query_type = linear
 db.iohandler.filename = data/gen1Din2D_one_multiply.spatialdb
 
@@ -55,7 +55,7 @@ shapers = [bg, subtract, divide]
 default = -1.0
 db_value = Two
 operand = add
-db.label = DB2: background
+db.description = DB2: background
 db.query_type = linear
 db.iohandler.filename = data/gen1Din2D_two_bg.spatialdb
 
@@ -63,7 +63,7 @@ db.iohandler.filename = data/gen1Din2D_two_bg.spatialdb
 default = 0.0
 operand = subtract
 db_value = Two
-db.label = DB2: subtract
+db.description = DB2: subtract
 db.query_type = linear
 db.iohandler.filename = data/gen1Din2D_two_subtract.spatialdb
 
@@ -71,7 +71,7 @@ db.iohandler.filename = data/gen1Din2D_two_subtract.spatialdb
 default = 1.0
 operand = divide
 db_value = Two
-db.label = DB2: divide
+db.description = DB2: divide
 db.query_type = linear
 db.iohandler.filename = data/gen1Din2D_two_divide.spatialdb
 


### PR DESCRIPTION
Change `label` to `description` in `SpatialDB` and `TimeHistory` to avoid confusion with other Pyre components using `label` in other contexts. For example, PyLith uses `label` to associate components with PETSc labels.