### PR TITLE
FIX: Use self.description instead of self.label in spatial database validateParameters()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## Version 3.1.0 (TBD)
 
 * Add `AnalyticDB` for a spatial database composed of analytic functions.
+* Bugfixes
+  - Update spatial database validateParameters() to use correct data member (self.label -> self.description).
 
 ## Version 3.0.0 (2022/06/06)
 

--- a/spatialdata/spatialdb/AnalyticDB.py
+++ b/spatialdata/spatialdb/AnalyticDB.py
@@ -81,23 +81,23 @@ class AnalyticDB(SpatialDBObj, ModuleAnalyticDB):
         Validate parameters.
         """
         if len(params.values) == 0:
-            raise ValueError("Values in AnalyticDB '%s' not specified.", self.label)
+            raise ValueError("Values in AnalyticDB '%s' not specified.", self.description)
         if len(params.units) == 0:
-            raise ValueError("Units for AnalyticDB '%s' not specified." % self.label)
+            raise ValueError("Units for AnalyticDB '%s' not specified." % self.description)
         if len(params.expressions) == 0:
-            raise ValueError("Analytical expressions for AnalyticDB '%s' not specified." % self.label)
+            raise ValueError("Analytical expressions for AnalyticDB '%s' not specified." % self.description)
         if len(params.values) != len(params.units or len(params.values) != len(params.expressions)):
             raise ValueError("Incompatible settings for uniform spatial database '%s'.\n"
                              "'values', 'units', and 'expressions' must be lists of the same size.\n"
                              "Size of 'values'=%d, 'units'=%d, and 'expressions'=%d."
-                             % (self.label, len(params.values), len(params.units), len(params.expressions)))
+                             % (self.description, len(params.values), len(params.units), len(params.expressions)))
         try:
             for x in params.units:
                 if len(str(x).split("*")) > 1:
                     xdim = self.parser.parse(str(x))
         except:
             raise ValueError(
-                "'units' for AnalyticDB '%s' must contain dimensioned or nondimensional values." % self.label)
+                "'units' for AnalyticDB '%s' must contain dimensioned or nondimensional values." % self.description)
 
 
 def spatial_database():

--- a/spatialdata/spatialdb/CompositeDB.py
+++ b/spatialdata/spatialdb/CompositeDB.py
@@ -86,10 +86,10 @@ class CompositeDB(SpatialDBObj, ModuleCompositeDB):
         """
         if (0 == len(data.namesA)):
             raise ValueError("Error in spatial database '%s'\n"
-                             "Names of values to query in database A not set." % self.label)
+                             "Names of values to query in database A not set." % self.description)
         if (0 == len(data.namesB)):
             raise ValueError("Error in spatial database '%s'\n"
-                             "Names of values to query in database B not set." % self.label)
+                             "Names of values to query in database B not set." % self.description)
         return
 
 

--- a/spatialdata/spatialdb/SimpleGridDB.py
+++ b/spatialdata/spatialdb/SimpleGridDB.py
@@ -84,7 +84,7 @@ class SimpleGridDB(SpatialDBObj, ModuleSimpleGridDB):
         elif label.lower() == "linear":
             value = ModuleSimpleGridDB.LINEAR
         else:
-            raise ValueError("Unknown value for query type '%s' in spatial database %s." % (label, self.label))
+            raise ValueError("Unknown value for query type '%s' in spatial database %s." % (label, self.description))
         return value
 
 

--- a/spatialdata/spatialdb/UniformDB.py
+++ b/spatialdata/spatialdb/UniformDB.py
@@ -88,14 +88,14 @@ class UniformDB(SpatialDBObj, ModuleUniformDB):
         Validate parameters.
         """
         if len(params.values) == 0:
-            raise ValueError("Values in UniformDB '%s' not specified.", self.label)
+            raise ValueError("Values in UniformDB '%s' not specified.", self.description)
         if len(params.data) == 0:
-            raise ValueError("Data for UniformDB '%s' not specified." % self.label)
+            raise ValueError("Data for UniformDB '%s' not specified." % self.description)
         if len(params.values) != len(params.data):
             raise ValueError("Incompatible settings for uniform spatial database '%s'.\n"
                              "'values' and 'data' must be lists of the same size.\n"
                              "'values' has size of %d but 'data' has size of %d."
-                             % (self.label, len(params.values), len(params.data)))
+                             % (self.description, len(params.values), len(params.data)))
         try:
             for x in params.data:
                 if len(str(x).split("*")) > 1:


### PR DESCRIPTION
Closes #83 